### PR TITLE
Introduce OutParameter types

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ For example demonstrations of the usage, go to [Ballerina By Examples](https://b
 
 2. Download and install [Docker](https://www.docker.com/get-started)
    
-3. Export Github Access Tokens with read package permissions.
+3. Export Github Access Tokens with read package permissions as follows,
         
-        export packageUser=<Your github username>
-        export packagePAT=<Your personnel access token>
+        export packageUser=<Username>
+        export packagePAT=<Access token>
 
 ### Building the Source
 

--- a/sql-ballerina/build.gradle
+++ b/sql-ballerina/build.gradle
@@ -168,9 +168,9 @@ task ballerinaTest {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$distributionBinPath/ballerina.bat test ${groupParams} --all ${debugParams} && exit %%ERRORLEVEL%%"
+                commandLine 'cmd', '/c', "$distributionBinPath/ballerina.bat test --code-coverage ${groupParams} --all ${debugParams} && exit %%ERRORLEVEL%%"
             } else {
-                commandLine 'sh', '-c', "$distributionBinPath/ballerina test ${groupParams} --all ${debugParams}"
+                commandLine 'sh', '-c', "$distributionBinPath/ballerina test --code-coverage ${groupParams} --all ${debugParams}"
             }
         }
     }

--- a/sql-ballerina/src/sql/Module.md
+++ b/sql-ballerina/src/sql/Module.md
@@ -347,7 +347,7 @@ This example demonstrates how to execute a stored procedure with a single INSERT
 
 ```ballerina
 int uid = 10;
-sql:OutParameter insertId = new;
+sql:IntegerOutParameter insertId = new;
 
 var ret = dbClient->call(`call InsertPerson(${uid}, ${insertId})`);
 if (ret is error) {

--- a/sql-ballerina/src/sql/types.bal
+++ b/sql-ballerina/src/sql/types.bal
@@ -396,9 +396,9 @@ class ResultIterator {
 public class CharOutParameter {
     # Parses returned Char SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -409,9 +409,9 @@ public class CharOutParameter {
 public class VarcharOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -420,9 +420,9 @@ public class VarcharOutParameter {
 public class NCharOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -431,9 +431,9 @@ public class NCharOutParameter {
 public class NVarcharOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -442,9 +442,9 @@ public class NVarcharOutParameter {
 public class BinaryOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -453,9 +453,9 @@ public class BinaryOutParameter {
 public class VarBinaryOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -464,9 +464,9 @@ public class VarBinaryOutParameter {
 public class TextOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -475,9 +475,9 @@ public class TextOutParameter {
 public class BlobOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -486,9 +486,9 @@ public class BlobOutParameter {
 public class ClobOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -497,9 +497,9 @@ public class ClobOutParameter {
 public class NClobOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -508,9 +508,9 @@ public class NClobOutParameter {
 public class DateOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -519,9 +519,9 @@ public class DateOutParameter {
 public class TimeOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -530,9 +530,9 @@ public class TimeOutParameter {
 public class DateTimeOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -541,9 +541,9 @@ public class DateTimeOutParameter {
 public class TimestampOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -552,9 +552,9 @@ public class TimestampOutParameter {
 public class ArrayOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -563,9 +563,9 @@ public class ArrayOutParameter {
 public class RowOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -574,9 +574,9 @@ public class RowOutParameter {
 public class SmallIntOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -585,9 +585,9 @@ public class SmallIntOutParameter {
 public class IntegerOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -596,9 +596,9 @@ public class IntegerOutParameter {
 public class BigIntOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -607,9 +607,9 @@ public class BigIntOutParameter {
 public class RealOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -618,9 +618,9 @@ public class RealOutParameter {
 public class FloatOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -629,9 +629,9 @@ public class FloatOutParameter {
 public class DoubleOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -640,9 +640,9 @@ public class DoubleOutParameter {
 public class NumericOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -651,9 +651,9 @@ public class NumericOutParameter {
 public class DecimalOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -662,9 +662,9 @@ public class DecimalOutParameter {
 public class BitOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -673,9 +673,9 @@ public class BitOutParameter {
 public class BooleanOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -684,9 +684,9 @@ public class BooleanOutParameter {
 public class RefOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -695,9 +695,9 @@ public class RefOutParameter {
 public class StructOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -706,9 +706,9 @@ public class StructOutParameter {
 public class XMLOutParameter {
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
@@ -723,9 +723,9 @@ public class InOutParameter {
 
     # Parses returned SQL value to ballerina value.
     #
-    # + td - Type description of the data that need to be converted
+    # + typeDesc - Type description of the data that need to be converted
     # + return - The converted ballerina value or Error
-    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error = @java:Method {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }

--- a/sql-ballerina/src/sql/types.bal
+++ b/sql-ballerina/src/sql/types.bal
@@ -392,9 +392,318 @@ class ResultIterator {
     }
 }
 
-# Represents SQL OutParameter used in procedure calls.
-public class OutParameter {
+# Represents Char Out Parameter used in procedure calls
+public class CharOutParameter {
+    # Parses returned Char SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
 
+
+
+# Represents Varchar Out Parameter used in procedure calls
+public class VarcharOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents NChar Out Parameter used in procedure calls
+public class NCharOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents NVarchar Out Parameter used in procedure calls
+public class NVarcharOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents Binary Out Parameter used in procedure calls
+public class BinaryOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents VarBinary Out Parameter used in procedure calls
+public class VarBinaryOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents Text Out Parameter used in procedure calls
+public class TextOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents Blob Out Parameter used in procedure calls
+public class BlobOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents Clob Out Parameter used in procedure calls
+public class ClobOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents NClob Out Parameter used in procedure calls
+public class NClobOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents Date Out Parameter used in procedure calls
+public class DateOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents Time Out Parameter used in procedure calls
+public class TimeOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents DateTime Out Parameter used in procedure calls
+public class DateTimeOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents Timestamp Out Parameter used in procedure calls
+public class TimestampOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents Array Out Parameter used in procedure calls
+public class ArrayOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents Row Out Parameter used in procedure calls
+public class RowOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents SmallInt Out Parameter used in procedure calls
+public class SmallIntOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents Integer Out Parameter used in procedure calls
+public class IntegerOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents BigInt Out Parameter used in procedure calls
+public class BigIntOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents Real Out Parameter used in procedure calls
+public class RealOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents Float Out Parameter used in procedure calls
+public class FloatOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents Double Out Parameter used in procedure calls
+public class DoubleOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents Numeric Out Parameter used in procedure calls
+public class NumericOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents Decimal Out Parameter used in procedure calls
+public class DecimalOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents Bit Out Parameter used in procedure calls
+public class BitOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents Boolean Out Parameter used in procedure calls
+public class BooleanOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents Ref Out Parameter used in procedure calls
+public class RefOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents Struct Out Parameter used in procedure calls
+public class StructOutParameter {
+    # Parses returned SQL value to ballerina value.
+    #
+    # + td - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> td) returns td|Error = @java:Method {
+        'class: "org.ballerinalang.sql.utils.OutParameterUtils"
+    } external;
+}
+
+# Represents XML Out Parameter used in procedure calls
+public class XMLOutParameter {
     # Parses returned SQL value to ballerina value.
     #
     # + td - Type description of the data that need to be converted
@@ -421,8 +730,18 @@ public class InOutParameter {
     } external;
 }
 
-# Represents all the parameters used in SQL stored procedure call.
-public type Parameter Value|OutParameter|InOutParameter;
+// todo Introduce OutParameter object type to simplify
+# Represents all OUT parameters used in SQL stored procedure call.
+public type OutParameter CharOutParameter|VarcharOutParameter|NCharOutParameter|NVarcharOutParameter|
+                         BinaryOutParameter|VarBinaryOutParameter|TextOutParameter|BlobOutParameter|
+                         ClobOutParameter|NClobOutParameter|DateOutParameter|TimeOutParameter|DateTimeOutParameter|
+                         TimestampOutParameter|ArrayOutParameter|RowOutParameter|SmallIntOutParameter|
+                         IntegerOutParameter|BigIntOutParameter|RealOutParameter|FloatOutParameter|DoubleOutParameter|
+                         NumericOutParameter|DecimalOutParameter|BitOutParameter|BooleanOutParameter|RefOutParameter|
+                         StructOutParameter|XMLOutParameter;
+
+# Represents all parameters used in SQL stored procedure call.
+public type Parameter Value|InOutParameter|OutParameter;
 
 # Represents Parameterized Call SQL Statement.
 #

--- a/sql-native/build.gradle
+++ b/sql-native/build.gradle
@@ -92,7 +92,7 @@ task validateSpotbugs() {
 checkstyle {
     toolVersion '7.8.2'
     configFile file("${rootDir}/build-config/checkstyle/build/checkstyle.xml")
-    configProperties = ["suppressionFile" : file("${rootDir}/build-config/checkstyle/build/suppressions.xml")]
+    configProperties = ["suppressionFile": file("${rootDir}/build-config/checkstyle/build/suppressions.xml")]
 }
 
 tasks.withType(Checkstyle) {

--- a/sql-native/src/main/java/org/ballerinalang/sql/Constants.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/Constants.java
@@ -49,8 +49,6 @@ public final class Constants {
     public static final String STATEMENT_NATIVE_DATA_FIELD = "Statement";
     public static final String COLUMN_DEFINITIONS_DATA_FIELD = "ColumnDefinition";
     public static final String RECORD_TYPE_DATA_FIELD = "recordType";
-    public static final String PROCEDURE_CALL_PARAM_CACHE = "procedureCallParamCache";
-    public static final String PROCEDURE_CALL_META_DATA = "procedureCallMetaData";
 
     public static final String PROCEDURE_CALL_RESULT = "ProcedureCallResult";
     public static final String TYPE_DESCRIPTIONS_NATIVE_DATA_FIELD = "TypeDescription";
@@ -147,6 +145,41 @@ public final class Constants {
         public static final String ROW = "RowValue";
         public static final String STRUCT = "StructValue";
 
+    }
+
+    /**
+     * Constants related to OutParameter supported.
+     */
+    public static final class OutParameterTypes {
+        public static final String CHAR = "CharOutParameter";
+        public static final String VARCHAR = "VarcharOutParameter";
+        public static final String NCHAR = "NCharOutParameter";
+        public static final String NVARCHAR = "NVarcharOutParameter";
+        public static final String BINARY = "BinaryOutParameter";
+        public static final String VARBINARY = "VarBinaryOutParameter";
+        public static final String TEXT = "TextOutParameter";
+        public static final String BLOB = "BlobOutParameter";
+        public static final String CLOB = "ClobOutParameter";
+        public static final String NCLOB = "NClobOutParameter";
+        public static final String DATE = "DateOutParameter";
+        public static final String TIME = "TimeOutParameter";
+        public static final String DATETIME = "DateTimeOutParameter";
+        public static final String TIMESTAMP = "TimestampOutParameter";
+        public static final String ARRAY = "ArrayOutParameter";
+        public static final String ROW = "RowOutParameter";
+        public static final String SMALLINT = "SmallIntOutParameter";
+        public static final String INTEGER = "IntegerOutParameter";
+        public static final String BIGINT = "BigIntOutParameter";
+        public static final String REAL = "RealOutParameter";
+        public static final String FLOAT = "FloatOutParameter";
+        public static final String DOUBLE = "DoubleOutParameter";
+        public static final String NUMERIC = "NumericOutParameter";
+        public static final String DECIMAL = "DecimalOutParameter";
+        public static final String BIT = "BitOutParameter";
+        public static final String BOOLEAN = "BooleanOutParameter";
+        public static final String REF = "RefOutParameter";
+        public static final String STRUCT = "StructOutParameter";
+        public static final String XML = "XMLOutParameter";
     }
 
     /**

--- a/sql-native/src/main/java/org/ballerinalang/sql/utils/ErrorGenerator.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/utils/ErrorGenerator.java
@@ -42,8 +42,8 @@ public class ErrorGenerator {
     }
 
     public static BError getSQLBatchExecuteError(SQLException exception,
-                                                     List<BMap<BString, Object>> executionResults,
-                                                     String messagePrefix) {
+                                                 List<BMap<BString, Object>> executionResults,
+                                                 String messagePrefix) {
         String sqlErrorMessage =
                 exception.getMessage() != null ? exception.getMessage() : Constants.BATCH_EXECUTE_ERROR_MESSAGE;
         int vendorCode = exception.getErrorCode();
@@ -67,7 +67,7 @@ public class ErrorGenerator {
     }
 
     private static BError getSQLBatchExecuteError(String message, int vendorCode, String sqlState,
-                                                      List<BMap<BString, Object>> executionResults) {
+                                                  List<BMap<BString, Object>> executionResults) {
         Map<String, Object> valueMap = new HashMap<>();
         valueMap.put(Constants.ErrorRecordFields.ERROR_CODE, vendorCode);
         valueMap.put(Constants.ErrorRecordFields.SQL_STATE, sqlState);

--- a/sql-native/src/main/java/org/ballerinalang/sql/utils/Utils.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/utils/Utils.java
@@ -197,6 +197,105 @@ class Utils {
         }
     }
 
+    public static int getOutParameterType(BObject typedValue) throws ApplicationError {
+        String sqlType = typedValue.getType().getName();
+        int sqlTypeValue;
+        switch (sqlType) {
+            case Constants.OutParameterTypes.VARCHAR:
+            case Constants.OutParameterTypes.TEXT:
+                sqlTypeValue = Types.VARCHAR;
+                break;
+            case Constants.OutParameterTypes.CHAR:
+                sqlTypeValue = Types.CHAR;
+                break;
+            case Constants.OutParameterTypes.NCHAR:
+                sqlTypeValue = Types.NCHAR;
+                break;
+            case Constants.OutParameterTypes.NVARCHAR:
+                sqlTypeValue = Types.NVARCHAR;
+                break;
+            case Constants.OutParameterTypes.BIT:
+                sqlTypeValue = Types.BIT;
+                break;
+            case Constants.OutParameterTypes.BOOLEAN:
+                sqlTypeValue = Types.BOOLEAN;
+                break;
+            case Constants.OutParameterTypes.INTEGER:
+                sqlTypeValue = Types.INTEGER;
+                break;
+            case Constants.OutParameterTypes.BIGINT:
+                sqlTypeValue = Types.BIGINT;
+                break;
+            case Constants.OutParameterTypes.SMALLINT:
+                sqlTypeValue = Types.SMALLINT;
+                break;
+            case Constants.OutParameterTypes.FLOAT:
+                sqlTypeValue = Types.FLOAT;
+                break;
+            case Constants.OutParameterTypes.REAL:
+                sqlTypeValue = Types.REAL;
+                break;
+            case Constants.OutParameterTypes.DOUBLE:
+                sqlTypeValue = Types.DOUBLE;
+                break;
+            case Constants.OutParameterTypes.NUMERIC:
+                sqlTypeValue = Types.NUMERIC;
+                break;
+            case Constants.OutParameterTypes.DECIMAL:
+                sqlTypeValue = Types.DECIMAL;
+                break;
+            case Constants.OutParameterTypes.BINARY:
+                sqlTypeValue = Types.BINARY;
+                break;
+            case Constants.OutParameterTypes.VARBINARY:
+                sqlTypeValue = Types.VARBINARY;
+                break;
+            case Constants.OutParameterTypes.BLOB:
+                if (typedValue instanceof ArrayValue) {
+                    sqlTypeValue = Types.VARBINARY;
+                } else {
+                    sqlTypeValue = Types.LONGVARBINARY;
+                }
+                break;
+            case Constants.OutParameterTypes.CLOB:
+            case Constants.OutParameterTypes.NCLOB:
+                if (typedValue instanceof BString) {
+                    sqlTypeValue = Types.CLOB;
+                } else {
+                    sqlTypeValue = Types.LONGVARCHAR;
+                }
+                break;
+            case Constants.OutParameterTypes.DATE:
+                sqlTypeValue = Types.DATE;
+                break;
+            case Constants.OutParameterTypes.TIME:
+                sqlTypeValue = Types.TIME;
+                break;
+            case Constants.OutParameterTypes.TIMESTAMP:
+            case Constants.OutParameterTypes.DATETIME:
+                sqlTypeValue = Types.TIMESTAMP;
+                break;
+            case Constants.OutParameterTypes.ARRAY:
+                sqlTypeValue = Types.ARRAY;
+                break;
+            case Constants.OutParameterTypes.REF:
+                sqlTypeValue = Types.REF;
+                break;
+            case Constants.OutParameterTypes.STRUCT:
+                sqlTypeValue = Types.STRUCT;
+                break;
+            case Constants.OutParameterTypes.ROW:
+                sqlTypeValue = Types.ROWID;
+                break;
+            case Constants.OutParameterTypes.XML:
+                sqlTypeValue = Types.SQLXML;
+                break;
+            default:
+                throw new ApplicationError("Unsupported OutParameter type: " + sqlType);
+        }
+        return sqlTypeValue;
+    }
+
     private static int getSQLType(BObject typedValue) throws ApplicationError {
         String sqlType = typedValue.getType().getName();
         int sqlTypeValue;

--- a/sql-native/src/main/java/org/ballerinalang/sql/utils/Utils.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/utils/Utils.java
@@ -1307,9 +1307,9 @@ class Utils {
     }
 
     public static BObject createRecordIterator(ResultSet resultSet,
-                                                   Statement statement,
-                                                   Connection connection, List<ColumnDefinition> columnDefinitions,
-                                                   BStructureType streamConstraint) {
+                                               Statement statement,
+                                               Connection connection, List<ColumnDefinition> columnDefinitions,
+                                               BStructureType streamConstraint) {
         BObject resultIterator = ValueCreator.createObjectValue(Constants.SQL_PACKAGE_ID,
                 Constants.RESULT_ITERATOR_OBJECT, new Object[1]);
         resultIterator.addNativeData(Constants.RESULT_SET_NATIVE_DATA_FIELD, resultSet);


### PR DESCRIPTION
## Purpose
Solve low privilege users not able to run stored procedures

## Goals
Allow users to define OutParameter types thus enabling all users can run stored procedures.
Fix https://github.com/ballerina-platform/ballerina-lang/issues/25869

## Approach
As discussed in https://github.com/ballerina-platform/ballerina-lang/issues/25869

## Release note
Fix low privilege users( Not able to access metadata) run stored procedures

## Automation tests
 - Unit tests - N/A
 - Integration tests Added in MySQL connector

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Migrations (if applicable)
Now `sql:OutParameter` should be changed to specific typed OutParameter class

## Test environment
JDK11, Ballerina-2.0.0-Preview5-SNAPSHOT as of 20/10/2020
 