### PR TITLE
Define `OutParameter` as object

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ Execute the commands below to build from source.
    batch-execute | batch-execute 
    query | query-simple-params<br>query-numeric-params<br>query-complex-params
 
-4. To disable some specific test groups:
+5. To disable some specific test groups:
 
         ./gradlew clean build -Pdisable-groups=<Comma separated groups/test cases>
 
-5. To debug the tests:
+6. To debug the tests:
 
         ./gradlew clean build -Pdebug=<port>
 

--- a/sql-ballerina/src/sql/types.bal
+++ b/sql-ballerina/src/sql/types.bal
@@ -392,6 +392,16 @@ class ResultIterator {
     }
 }
 
+# Represents all OUT parameters used in SQL stored procedure call.
+public type OutParameter object {
+
+    # Parses returned Char SQL value to ballerina value.
+    #
+    # + typeDesc - Type description of the data that need to be converted
+    # + return - The converted ballerina value or Error
+    public isolated function get(typedesc<anydata> typeDesc) returns typeDesc|Error;
+};
+
 # Represents Char Out Parameter used in procedure calls
 public class CharOutParameter {
     # Parses returned Char SQL value to ballerina value.
@@ -727,16 +737,6 @@ public class InOutParameter {
         'class: "org.ballerinalang.sql.utils.OutParameterUtils"
     } external;
 }
-
-// todo Introduce OutParameter object type to simplify
-# Represents all OUT parameters used in SQL stored procedure call.
-public type OutParameter CharOutParameter|VarcharOutParameter|NCharOutParameter|NVarcharOutParameter|
-                         BinaryOutParameter|VarBinaryOutParameter|TextOutParameter|BlobOutParameter|
-                         ClobOutParameter|NClobOutParameter|DateOutParameter|TimeOutParameter|DateTimeOutParameter|
-                         TimestampOutParameter|ArrayOutParameter|RowOutParameter|SmallIntOutParameter|
-                         IntegerOutParameter|BigIntOutParameter|RealOutParameter|FloatOutParameter|DoubleOutParameter|
-                         NumericOutParameter|DecimalOutParameter|BitOutParameter|BooleanOutParameter|RefOutParameter|
-                         StructOutParameter|XMLOutParameter;
 
 # Represents all parameters used in SQL stored procedure call.
 public type Parameter Value|InOutParameter|OutParameter;


### PR DESCRIPTION
## Purpose
$subject instead of union type. 
Reverts temporary fix for https://github.com/ballerina-platform/ballerina-lang/issues/26430

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes