### PR TITLE
Add Abstract and Concrete ResultParameterProcessor Classes

### DIFF
--- a/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/AbstractResultParameterProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/AbstractResultParameterProcessor.java
@@ -44,7 +44,6 @@ import java.util.List;
  *
  * @since 0.5.6
  */
- */
 public abstract class AbstractResultParameterProcessor {
 
     protected abstract BArray createAndPopulateCustomValueArray(Object firstNonNullElement, Object[] dataArray)

--- a/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/AbstractResultParameterProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/AbstractResultParameterProcessor.java
@@ -1,0 +1,187 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.sql.parameterprocessor;
+
+import io.ballerina.runtime.api.types.Field;
+import io.ballerina.runtime.api.types.StructureType;
+import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.values.BArray;
+import io.ballerina.runtime.api.values.BObject;
+import io.ballerina.runtime.api.values.BString;
+import org.ballerinalang.sql.exception.ApplicationError;
+import org.ballerinalang.sql.utils.ColumnDefinition;
+
+import java.math.BigDecimal;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLXML;
+import java.sql.Statement;
+import java.sql.Struct;
+import java.util.List;
+
+/**
+ * This class has abstract implementation of methods required convert SQL types into ballerina types and
+ * other methods that process the parameters of the result.
+ */
+public abstract class AbstractResultParameterProcessor {
+
+    protected abstract BArray createAndPopulateCustomValueArray(Object firstNonNullElement, Object[] dataArray)
+            throws ApplicationError;
+
+    protected abstract BArray createAndPopulateCustomBBRefValueArray(Object firstNonNullElement, Object[] dataArray,
+                                                                     Type type) throws ApplicationError;
+
+    protected abstract void createUserDefinedTypeSubtype(Field internalField, StructureType structType)
+            throws ApplicationError;
+
+    protected abstract BArray convert(Array array, int sqlType, Type type) throws SQLException, ApplicationError;
+
+    protected abstract BString convert(String value, int sqlType, Type type) throws ApplicationError;
+
+    protected abstract Object convert(String value, int sqlType, Type type, String sqlTypeName) throws ApplicationError;
+
+    protected abstract Object convert(byte[] value, int sqlType, Type type, String sqlTypeName) throws ApplicationError;
+
+    protected abstract Object convert(long value, int sqlType, Type type, boolean isNull) throws ApplicationError;
+
+    protected abstract Object convert(double value, int sqlType, Type type, boolean isNull) throws ApplicationError;
+
+    protected abstract Object convert(BigDecimal value, int sqlType, Type type, boolean isNull) throws ApplicationError;
+
+    protected abstract Object convert(Blob value, int sqlType, Type type) throws ApplicationError, SQLException;
+
+    protected abstract Object convert(java.util.Date date, int sqlType, Type type) throws ApplicationError;
+
+    protected abstract Object convert(boolean value, int sqlType, Type type, boolean isNull) throws ApplicationError;
+
+    protected abstract Object convert(Struct value, int sqlType, Type type) throws ApplicationError;
+
+    protected abstract Object convert(SQLXML value, int sqlType, Type type) throws ApplicationError, SQLException;
+
+    protected abstract void populateChar(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateVarchar(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateLongVarchar(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateNChar(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateNVarchar(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateLongNVarchar(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateBinary(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateVarBinary(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateLongVarBinary(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateBlob(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateClob(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateNClob(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateDate(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateTime(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateTimeWithTimeZone(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateTimestamp(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateTimestampWithTimeZone(
+            CallableStatement statement, BObject parameter, int paramIndex) throws SQLException;
+
+    protected abstract void populateArray(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateRowID(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateTinyInt(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateSmallInt(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateInteger(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateBigInt(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateReal(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateFloat(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateDouble(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateNumeric(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateDecimal(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateBit(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateBoolean(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateRef(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateStruct(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    protected abstract void populateXML(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException;
+
+    public abstract void populateCustomOutParameters(
+            CallableStatement statement, BObject parameter, int paramIndex, int sqlType) throws ApplicationError;
+
+    protected abstract Object getCustomOutParameters(Object value, int sqlType, Type ballerinaType);
+
+    public abstract BObject createRecordIterator(
+            ResultSet resultSet, Statement statement, Connection connection,
+            List<ColumnDefinition> columnDefinitions, StructureType streamConstraint);
+}

--- a/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/AbstractResultParameterProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/AbstractResultParameterProcessor.java
@@ -41,6 +41,9 @@ import java.util.List;
 /**
  * This class has abstract implementation of methods required convert SQL types into ballerina types and
  * other methods that process the parameters of the result.
+ *
+ * @since 0.5.6
+ */
  */
 public abstract class AbstractResultParameterProcessor {
 

--- a/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/AbstractResultParameterProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/AbstractResultParameterProcessor.java
@@ -44,6 +44,7 @@ import java.util.List;
  *
  * @since 0.5.6
  */
+ */
 public abstract class AbstractResultParameterProcessor {
 
     protected abstract BArray createAndPopulateCustomValueArray(Object firstNonNullElement, Object[] dataArray)

--- a/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/ResultParameterProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/ResultParameterProcessor.java
@@ -1,0 +1,759 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.sql.parameterprocessor;
+
+import io.ballerina.runtime.api.PredefinedTypes;
+import io.ballerina.runtime.api.TypeTags;
+import io.ballerina.runtime.api.creators.TypeCreator;
+import io.ballerina.runtime.api.creators.ValueCreator;
+import io.ballerina.runtime.api.types.ArrayType;
+import io.ballerina.runtime.api.types.Field;
+import io.ballerina.runtime.api.types.RecordType;
+import io.ballerina.runtime.api.types.StructureType;
+import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.types.UnionType;
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.utils.XmlUtils;
+import io.ballerina.runtime.api.values.BArray;
+import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.runtime.api.values.BObject;
+import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BXml;
+import org.ballerinalang.sql.Constants;
+import org.ballerinalang.sql.exception.ApplicationError;
+import org.ballerinalang.sql.utils.ColumnDefinition;
+import org.ballerinalang.sql.utils.ErrorGenerator;
+import org.ballerinalang.sql.utils.ModuleUtils;
+import org.ballerinalang.sql.utils.Utils;
+
+import java.math.BigDecimal;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLXML;
+import java.sql.Statement;
+import java.sql.Struct;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+import java.util.TimeZone;
+
+import static io.ballerina.runtime.api.utils.StringUtils.fromString;
+
+/**
+ * This class implements methods required convert SQL types into ballerina types and
+ * other methods that process the parameters of the result.
+ */
+public class ResultParameterProcessor extends AbstractResultParameterProcessor {
+    private static final Object lock = new Object();
+    private static volatile ResultParameterProcessor instance;
+
+    private static final ArrayType stringArrayType = TypeCreator.createArrayType(PredefinedTypes.TYPE_STRING);
+    private static final ArrayType booleanArrayType = TypeCreator.createArrayType(PredefinedTypes.TYPE_BOOLEAN);
+    private static final ArrayType intArrayType = TypeCreator.createArrayType(PredefinedTypes.TYPE_INT);
+    private static final ArrayType floatArrayType = TypeCreator.createArrayType(PredefinedTypes.TYPE_FLOAT);
+    private static final ArrayType decimalArrayType = TypeCreator.createArrayType(PredefinedTypes.TYPE_DECIMAL);
+
+    private static final Calendar calendar = Calendar
+            .getInstance(TimeZone.getTimeZone(Constants.TIMEZONE_UTC.getValue()));
+
+
+    public static ResultParameterProcessor getInstance() {
+        if (instance == null) {
+            synchronized (lock) {
+                if (instance == null) {
+                    instance = new ResultParameterProcessor();
+                }
+            }
+        }
+        return instance;
+    }
+
+    protected BArray createAndPopulateBBRefValueArray(Object firstNonNullElement, Object[] dataArray,
+                                                      Type type) throws ApplicationError {
+        BArray refValueArray = null;
+        int length = dataArray.length;
+        if (firstNonNullElement instanceof String) {
+            refValueArray = createEmptyBBRefValueArray(PredefinedTypes.TYPE_STRING);
+            for (int i = 0; i < length; i++) {
+                refValueArray.add(i, dataArray[i]);
+            }
+        } else if (firstNonNullElement instanceof Boolean) {
+            refValueArray = createEmptyBBRefValueArray(PredefinedTypes.TYPE_BOOLEAN);
+            for (int i = 0; i < length; i++) {
+                refValueArray.add(i, dataArray[i]);
+            }
+        } else if (firstNonNullElement instanceof Integer) {
+            refValueArray = createEmptyBBRefValueArray(PredefinedTypes.TYPE_INT);
+            for (int i = 0; i < length; i++) {
+                refValueArray.add(i, dataArray[i]);
+            }
+        } else if (firstNonNullElement instanceof Long) {
+            refValueArray = createEmptyBBRefValueArray(PredefinedTypes.TYPE_INT);
+            for (int i = 0; i < length; i++) {
+                refValueArray.add(i, dataArray[i]);
+            }
+        } else if (firstNonNullElement instanceof Float) {
+            refValueArray = createEmptyBBRefValueArray(PredefinedTypes.TYPE_FLOAT);
+            for (int i = 0; i < length; i++) {
+                refValueArray.add(i, dataArray[i]);
+            }
+        } else if (firstNonNullElement instanceof Double) {
+            refValueArray = createEmptyBBRefValueArray(PredefinedTypes.TYPE_FLOAT);
+            for (int i = 0; i < length; i++) {
+                refValueArray.add(i, dataArray[i]);
+            }
+        } else if (firstNonNullElement instanceof BigDecimal) {
+            refValueArray = createEmptyBBRefValueArray(PredefinedTypes.TYPE_DECIMAL);
+            for (int i = 0; i < length; i++) {
+                refValueArray.add(i,
+                        dataArray[i] != null ? ValueCreator.createDecimalValue((BigDecimal) dataArray[i]) : null);
+            }
+        } else if (firstNonNullElement == null) {
+            refValueArray = createEmptyBBRefValueArray(type);
+            for (int i = 0; i < length; i++) {
+                refValueArray.add(i, firstNonNullElement);
+            }
+        } else {
+            createAndPopulateCustomBBRefValueArray(firstNonNullElement, dataArray, type);
+        }
+        return refValueArray;
+    }
+
+    protected BArray createEmptyBBRefValueArray(Type type) {
+        List<Type> memberTypes = new ArrayList<>(2);
+        memberTypes.add(type);
+        memberTypes.add(PredefinedTypes.TYPE_NULL);
+        UnionType unionType = TypeCreator.createUnionType(memberTypes);
+        return ValueCreator.createArrayValue(TypeCreator.createArrayType(unionType));
+    }
+
+    @Override
+    protected BArray createAndPopulateCustomBBRefValueArray(Object firstNonNullElement, Object[] dataArray,
+                                                            Type type) {
+        return null;
+    }
+
+    protected BArray createAndPopulatePrimitiveValueArray(Object firstNonNullElement, Object[] dataArray)
+            throws ApplicationError {
+        int length = dataArray.length;
+        if (firstNonNullElement instanceof String) {
+            BArray stringDataArray = ValueCreator.createArrayValue(stringArrayType);
+            for (int i = 0; i < length; i++) {
+                stringDataArray.add(i, StringUtils.fromString((String) dataArray[i]));
+            }
+            return stringDataArray;
+        } else if (firstNonNullElement instanceof Boolean) {
+            BArray boolDataArray = ValueCreator.createArrayValue(booleanArrayType);
+            for (int i = 0; i < length; i++) {
+                boolDataArray.add(i, ((Boolean) dataArray[i]).booleanValue());
+            }
+            return boolDataArray;
+        } else if (firstNonNullElement instanceof Integer) {
+            BArray intDataArray = ValueCreator.createArrayValue(intArrayType);
+            for (int i = 0; i < length; i++) {
+                intDataArray.add(i, ((Integer) dataArray[i]).intValue());
+            }
+            return intDataArray;
+        } else if (firstNonNullElement instanceof Long) {
+            BArray longDataArray = ValueCreator.createArrayValue(intArrayType);
+            for (int i = 0; i < length; i++) {
+                longDataArray.add(i, ((Long) dataArray[i]).longValue());
+            }
+            return longDataArray;
+        } else if (firstNonNullElement instanceof Float) {
+            BArray floatDataArray = ValueCreator.createArrayValue(floatArrayType);
+            for (int i = 0; i < length; i++) {
+                floatDataArray.add(i, ((Float) dataArray[i]).floatValue());
+            }
+            return floatDataArray;
+        } else if (firstNonNullElement instanceof Double) {
+            BArray doubleDataArray = ValueCreator.createArrayValue(floatArrayType);
+            for (int i = 0; i < dataArray.length; i++) {
+                doubleDataArray.add(i, ((Double) dataArray[i]).doubleValue());
+            }
+            return doubleDataArray;
+        } else if ((firstNonNullElement instanceof BigDecimal)) {
+            BArray decimalDataArray = ValueCreator.createArrayValue(decimalArrayType);
+            for (int i = 0; i < dataArray.length; i++) {
+                decimalDataArray.add(i, ValueCreator.createDecimalValue((BigDecimal) dataArray[i]));
+            }
+            return decimalDataArray;
+        } else {
+            return createAndPopulateCustomValueArray(firstNonNullElement, dataArray);
+        }
+    }
+
+    @Override
+    protected BArray createAndPopulateCustomValueArray(Object firstNonNullElement, Object[] dataArray) {
+        return null;
+    }
+
+    protected BMap<BString, Object> createUserDefinedType(Struct structValue, StructureType structType)
+            throws ApplicationError {
+        if (structValue == null) {
+            return null;
+        }
+        Field[] internalStructFields = structType.getFields().values().toArray(new Field[0]);
+        BMap<BString, Object> struct = ValueCreator.createMapValue(structType);
+        try {
+            Object[] dataArray = structValue.getAttributes();
+            if (dataArray != null) {
+                if (dataArray.length != internalStructFields.length) {
+                    throw new ApplicationError("specified record and the returned SQL Struct field counts " +
+                            "are different, and hence not compatible");
+                }
+                int index = 0;
+                for (Field internalField : internalStructFields) {
+                    int type = internalField.getFieldType().getTag();
+                    BString fieldName = fromString(internalField.getFieldName());
+                    Object value = dataArray[index];
+                    switch (type) {
+                        case TypeTags.INT_TAG:
+                            if (value instanceof BigDecimal) {
+                                struct.put(fieldName, ((BigDecimal) value).intValue());
+                            } else {
+                                struct.put(fieldName, value);
+                            }
+                            break;
+                        case TypeTags.FLOAT_TAG:
+                            if (value instanceof BigDecimal) {
+                                struct.put(fieldName, ((BigDecimal) value).doubleValue());
+                            } else {
+                                struct.put(fieldName, value);
+                            }
+                            break;
+                        case TypeTags.DECIMAL_TAG:
+                            if (value instanceof BigDecimal) {
+                                struct.put(fieldName, value);
+                            } else {
+                                struct.put(fieldName, ValueCreator.createDecimalValue((BigDecimal) value));
+                            }
+                            break;
+                        case TypeTags.STRING_TAG:
+                            struct.put(fieldName, value);
+                            break;
+                        case TypeTags.BOOLEAN_TAG:
+                            struct.put(fieldName, ((int) value) == 1);
+                            break;
+                        case TypeTags.OBJECT_TYPE_TAG:
+                        case TypeTags.RECORD_TYPE_TAG:
+                            struct.put(fieldName,
+                                    createUserDefinedType((Struct) value,
+                                            (StructureType) internalField.getFieldType()));
+                            break;
+                        default:
+                            createUserDefinedTypeSubtype(internalField, structType);
+                    }
+                    ++index;
+                }
+            }
+        } catch (SQLException e) {
+            throw new ApplicationError("Error while retrieving data to create " + structType.getName()
+                    + " record. ", e);
+        }
+        return struct;
+    }
+
+    @Override
+    protected void createUserDefinedTypeSubtype(Field internalField, StructureType structType)
+            throws ApplicationError {
+        throw new ApplicationError("Error while retrieving data for unsupported type " +
+                internalField.getFieldType().getName() + " to create "
+                + structType.getName() + " record.");
+    }
+
+    protected static Object[] validateNullable(Object[] objects) {
+        Object[] returnResult = new Object[2];
+        boolean foundNull = false;
+        Object nonNullObject = null;
+        for (Object object : objects) {
+            if (object != null) {
+                if (nonNullObject == null) {
+                    nonNullObject = object;
+                }
+                if (foundNull) {
+                    break;
+                }
+            } else {
+                foundNull = true;
+                if (nonNullObject != null) {
+                    break;
+                }
+            }
+        }
+        returnResult[0] = nonNullObject;
+        returnResult[1] = foundNull;
+        return returnResult;
+    }
+
+    @Override
+    public BArray convert(Array array, int sqlType, Type type) throws SQLException, ApplicationError {
+        if (array != null) {
+            Utils.validatedInvalidFieldAssignment(sqlType, type, "SQL Array");
+            Object[] dataArray = (Object[]) array.getArray();
+            if (dataArray == null || dataArray.length == 0) {
+                return null;
+            }
+
+            Object[] result = validateNullable(dataArray);
+            Object firstNonNullElement = result[0];
+            boolean containsNull = (boolean) result[1];
+
+            if (containsNull) {
+                // If there are some null elements, return a union-type element array
+                return createAndPopulateBBRefValueArray(firstNonNullElement, dataArray, type);
+            } else {
+                // If there are no null elements, return a ballerina primitive-type array
+                return createAndPopulatePrimitiveValueArray(firstNonNullElement, dataArray);
+            }
+
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public BString convert(String value, int sqlType, Type type) throws ApplicationError {
+        Utils.validatedInvalidFieldAssignment(sqlType, type, "SQL String");
+        return fromString(value);
+    }
+
+    @Override
+    public Object convert(
+            String value, int sqlType, Type type, String sqlTypeName) throws ApplicationError {
+        Utils.validatedInvalidFieldAssignment(sqlType, type, sqlTypeName);
+        return fromString(value);
+    }
+
+    @Override
+    public Object convert(byte[] value, int sqlType, Type type, String sqlTypeName) throws ApplicationError {
+        if (value != null) {
+            return ValueCreator.createArrayValue(value);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public Object convert(long value, int sqlType, Type type, boolean isNull) throws ApplicationError {
+        Utils.validatedInvalidFieldAssignment(sqlType, type, "SQL long or integer");
+        if (isNull) {
+            return null;
+        } else {
+            if (type.getTag() == TypeTags.STRING_TAG) {
+                return fromString(String.valueOf(value));
+            }
+            return value;
+        }
+    }
+
+    @Override
+    public Object convert(double value, int sqlType, Type type, boolean isNull) throws ApplicationError {
+        Utils.validatedInvalidFieldAssignment(sqlType, type, "SQL double or float");
+        if (isNull) {
+            return null;
+        } else {
+            if (type.getTag() == TypeTags.STRING_TAG) {
+                return fromString(String.valueOf(value));
+            }
+            return value;
+        }
+    }
+
+    @Override
+    public Object convert(BigDecimal value, int sqlType, Type type, boolean isNull) throws ApplicationError {
+        Utils.validatedInvalidFieldAssignment(sqlType, type, "SQL decimal or real");
+        if (isNull) {
+            return null;
+        } else {
+            if (type.getTag() == TypeTags.STRING_TAG) {
+                return fromString(String.valueOf(value));
+            }
+            return ValueCreator.createDecimalValue(value);
+        }
+    }
+
+    @Override
+    public Object convert(Blob value, int sqlType, Type type) throws ApplicationError, SQLException {
+        Utils.validatedInvalidFieldAssignment(sqlType, type, "SQL Blob");
+        if (value != null) {
+            return ValueCreator.createArrayValue(value.getBytes(1L, (int) value.length()));
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public Object convert(java.util.Date date, int sqlType, Type type) throws ApplicationError {
+        Utils.validatedInvalidFieldAssignment(sqlType, type, "SQL Date/Time");
+        if (date != null) {
+            switch (type.getTag()) {
+                case TypeTags.STRING_TAG:
+                    return fromString(Utils.getString(date));
+                case TypeTags.OBJECT_TYPE_TAG:
+                case TypeTags.RECORD_TYPE_TAG:
+                    return Utils.createTimeStruct(date.getTime());
+                case TypeTags.INT_TAG:
+                    return date.getTime();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Object convert(boolean value, int sqlType, Type type, boolean isNull) throws ApplicationError {
+        Utils.validatedInvalidFieldAssignment(sqlType, type, "SQL Boolean");
+        if (!isNull) {
+            switch (type.getTag()) {
+                case TypeTags.BOOLEAN_TAG:
+                    return value;
+                case TypeTags.INT_TAG:
+                    if (value) {
+                        return 1L;
+                    } else {
+                        return 0L;
+                    }
+                case TypeTags.STRING_TAG:
+                    return fromString(String.valueOf(value));
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Object convert(Struct value, int sqlType, Type type) throws ApplicationError {
+        Utils.validatedInvalidFieldAssignment(sqlType, type, "SQL Struct");
+        if (value != null) {
+            if (type instanceof RecordType) {
+                return createUserDefinedType(value, (RecordType) type);
+            } else {
+                throw new ApplicationError("The ballerina type that can be used for SQL struct should be record type," +
+                        " but found " + type.getName() + " .");
+            }
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public Object convert(SQLXML value, int sqlType, Type type) throws ApplicationError, SQLException {
+        Utils.validatedInvalidFieldAssignment(sqlType, type, "SQL XML");
+        if (value != null) {
+            if (type instanceof BXml) {
+                return XmlUtils.parse(value.getBinaryStream());
+            } else {
+                throw new ApplicationError("The ballerina type that can be used for SQL struct should be record type," +
+                        " but found " + type.getName() + " .");
+            }
+        } else {
+            return null;
+        }
+    }
+
+    private void populateCharacterTypes(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA,
+                statement.getString(paramIndex));
+    }
+
+    private void populateFloatAndReal(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA,
+                statement.getFloat(paramIndex));
+    }
+
+    private void populateNumericAndDecimal(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA,
+                statement.getBigDecimal(paramIndex));
+    }
+
+    private void populateBitAndBoolean(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA,
+                statement.getBoolean(paramIndex));
+    }
+
+    private void populateRefAndStruct(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA,
+                statement.getObject(paramIndex));
+    }
+
+    @Override
+    protected void populateChar(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        populateCharacterTypes(statement, parameter, paramIndex);
+    }
+
+    @Override
+    protected void populateVarchar(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        populateCharacterTypes(statement, parameter, paramIndex);
+    }
+
+    @Override
+    protected void populateLongVarchar(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        populateCharacterTypes(statement, parameter, paramIndex);
+    }
+
+    @Override
+    protected void populateNChar(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        populateCharacterTypes(statement, parameter, paramIndex);
+    }
+
+    @Override
+    protected void populateNVarchar(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        populateCharacterTypes(statement, parameter, paramIndex);
+    }
+
+    @Override
+    protected void populateLongNVarchar(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        populateCharacterTypes(statement, parameter, paramIndex);
+    }
+
+    @Override
+    protected void populateBinary(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        populateCharacterTypes(statement, parameter, paramIndex);
+    }
+
+    @Override
+
+    protected void populateVarBinary(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        populateCharacterTypes(statement, parameter, paramIndex);
+    }
+
+    @Override
+    protected void populateLongVarBinary(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        populateCharacterTypes(statement, parameter, paramIndex);
+    }
+
+    @Override
+    protected void populateBlob(CallableStatement statement, BObject parameter, int paramIndex) throws SQLException {
+        parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA,
+                statement.getBlob(paramIndex));
+    }
+
+    @Override
+    protected void populateClob(CallableStatement statement, BObject parameter, int paramIndex) throws SQLException {
+        parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA,
+                statement.getClob(paramIndex));
+    }
+
+    @Override
+    protected void populateNClob(CallableStatement statement, BObject parameter, int paramIndex) throws SQLException {
+        parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA,
+                statement.getNClob(paramIndex));
+    }
+
+    @Override
+    protected void populateDate(CallableStatement statement, BObject parameter, int paramIndex) throws SQLException {
+        parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA,
+                statement.getDate(paramIndex, calendar));
+    }
+
+    @Override
+    protected void populateTime(CallableStatement statement, BObject parameter, int paramIndex) throws SQLException {
+        parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA,
+                statement.getTime(paramIndex, calendar));
+    }
+
+    @Override
+    protected void populateTimeWithTimeZone(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        try {
+            Time time = statement.getTime(paramIndex, calendar);
+            parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA, time);
+        } catch (SQLException ex) {
+            //Some database drivers do not support getTime operation,
+            // therefore falling back to getObject method.
+            OffsetTime offsetTime = statement.getObject(paramIndex, OffsetTime.class);
+            parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA,
+                    Time.valueOf(offsetTime.toLocalTime()));
+        }
+    }
+
+    @Override
+    protected void populateTimestamp(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA,
+                statement.getTimestamp(paramIndex, calendar));
+    }
+
+    @Override
+    protected void populateTimestampWithTimeZone(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        try {
+            parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA,
+                    statement.getTimestamp(paramIndex, calendar));
+        } catch (SQLException ex) {
+            //Some database drivers do not support getTimestamp operation,
+            // therefore falling back to getObject method.
+            OffsetDateTime offsetDateTime = statement.getObject(paramIndex, OffsetDateTime.class);
+            parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA,
+                    Timestamp.valueOf(offsetDateTime.toLocalDateTime()));
+        }
+    }
+
+    @Override
+    protected void populateArray(CallableStatement statement, BObject parameter, int paramIndex) throws SQLException {
+        parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA,
+                statement.getArray(paramIndex));
+    }
+
+    @Override
+    protected void populateRowID(CallableStatement statement, BObject parameter, int paramIndex) throws SQLException {
+        parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA,
+                statement.getRowId(paramIndex));
+    }
+
+    @Override
+    protected void populateTinyInt(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA, statement.getInt(paramIndex));
+    }
+
+    @Override
+    protected void populateSmallInt(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA,
+                Integer.valueOf(statement.getShort(paramIndex)));
+    }
+
+    @Override
+    protected void populateInteger(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA,
+                Long.valueOf(statement.getInt(paramIndex)));
+    }
+
+    @Override
+    protected void populateBigInt(CallableStatement statement, BObject parameter, int paramIndex) throws SQLException {
+        parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA, statement.getLong(paramIndex));
+    }
+
+    @Override
+    protected void populateReal(CallableStatement statement, BObject parameter, int paramIndex) throws SQLException {
+        populateFloatAndReal(statement, parameter, paramIndex);
+    }
+
+    @Override
+    protected void populateFloat(CallableStatement statement, BObject parameter, int paramIndex)
+            throws SQLException {
+        populateFloatAndReal(statement, parameter, paramIndex);
+    }
+
+    @Override
+    protected void populateDouble(CallableStatement statement, BObject parameter, int paramIndex) throws SQLException {
+        parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA,
+                statement.getDouble(paramIndex));
+    }
+
+    @Override
+    protected void populateNumeric(CallableStatement statement, BObject parameter, int paramIndex) throws SQLException {
+        populateNumericAndDecimal(statement, parameter, paramIndex);
+
+    }
+
+    @Override
+    protected void populateDecimal(CallableStatement statement, BObject parameter, int paramIndex) throws SQLException {
+        populateNumericAndDecimal(statement, parameter, paramIndex);
+    }
+
+    @Override
+    protected void populateBit(CallableStatement statement, BObject parameter, int paramIndex) throws SQLException {
+        populateBitAndBoolean(statement, parameter, paramIndex);
+
+    }
+
+    @Override
+    protected void populateBoolean(CallableStatement statement, BObject parameter, int paramIndex) throws SQLException {
+        populateBitAndBoolean(statement, parameter, paramIndex);
+    }
+
+    @Override
+    protected void populateRef(CallableStatement statement, BObject parameter, int paramIndex) throws SQLException {
+        populateRefAndStruct(statement, parameter, paramIndex);
+    }
+
+    @Override
+    protected void populateStruct(CallableStatement statement, BObject parameter, int paramIndex) throws SQLException {
+        populateRefAndStruct(statement, parameter, paramIndex);
+    }
+
+    @Override
+    protected void populateXML(CallableStatement statement, BObject parameter, int paramIndex) throws SQLException {
+        parameter.addNativeData(Constants.ParameterObject.VALUE_NATIVE_DATA,
+                statement.getSQLXML(paramIndex));
+    }
+
+    @Override
+    public void populateCustomOutParameters(CallableStatement statement, BObject parameter, int paramIndex, int sqlType)
+            throws ApplicationError {
+        throw new ApplicationError("Unsupported SQL type '" + sqlType + "' when reading Procedure call " +
+                "Out parameter of index '" + paramIndex + "'.");
+    }
+
+    @Override
+    public Object getCustomOutParameters(Object value, int sqlType, Type ballerinaType) {
+        return ErrorGenerator.getSQLApplicationError("Unsupported SQL type " + sqlType);
+    }
+
+    protected BObject getIteratorObject() {
+        return null;
+    }
+
+    public BObject createRecordIterator(ResultSet resultSet,
+                                        Statement statement,
+                                        Connection connection, List<ColumnDefinition> columnDefinitions,
+                                        StructureType streamConstraint) {
+        BObject iteratorObject = this.getIteratorObject();
+        BObject resultIterator = ValueCreator.createObjectValue(ModuleUtils.getModule(),
+                Constants.RESULT_ITERATOR_OBJECT, new Object[]{null, iteratorObject});
+        resultIterator.addNativeData(Constants.RESULT_SET_NATIVE_DATA_FIELD, resultSet);
+        resultIterator.addNativeData(Constants.STATEMENT_NATIVE_DATA_FIELD, statement);
+        resultIterator.addNativeData(Constants.CONNECTION_NATIVE_DATA_FIELD, connection);
+        resultIterator.addNativeData(Constants.COLUMN_DEFINITIONS_DATA_FIELD, columnDefinitions);
+        resultIterator.addNativeData(Constants.RECORD_TYPE_DATA_FIELD, streamConstraint);
+        return resultIterator;
+    }
+
+    public Object getCustomResult(ResultSet resultSet, int columnIndex, ColumnDefinition columnDefinition)
+            throws ApplicationError {
+        throw new ApplicationError("Unsupported SQL type " + columnDefinition.getSqlName());
+    }
+
+    public BObject getCustomProcedureCallObject() {
+        return null;
+    }
+}

--- a/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/ResultParameterProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/ResultParameterProcessor.java
@@ -65,6 +65,8 @@ import static io.ballerina.runtime.api.utils.StringUtils.fromString;
 /**
  * This class implements methods required convert SQL types into ballerina types and
  * other methods that process the parameters of the result.
+ *
+ * @since 0.5.6
  */
 public class ResultParameterProcessor extends AbstractResultParameterProcessor {
     private static final Object lock = new Object();


### PR DESCRIPTION
## Purpose

- To refactor `ballerina/sql` to support custom datatype handling for different database connector modules.

## Goals

- Close issues [#880](https://github.com/ballerina-platform/ballerina-standard-library/issues/880) [#883](https://github.com/ballerina-platform/ballerina-standard-library/issues/883)

## Approach

- The `AbstractResultParameterProcessor` class has the abstract implementation of the methods required to convert the SQL types in the result of database operations into ballerina types and other methods that are related to that task.

- The `ResultParameterProcessor` class contains the implementation of those methods with protected access modifier to allow connector modules to extend the functionality if needed.

## Documentation
- [SQL Refactor Proposal](https://docs.google.com/document/d/1Xs8pPqEG4aSbGqX1a9C6J-rAjwIe6SmMx0PMkC34xfs/edit?usp=sharing)

## Related PRs
- #91 , #92 , #87 