### PR TITLE
Refactor types.bal

### DIFF
--- a/sql-ballerina/types.bal
+++ b/sql-ballerina/types.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/sql-ballerina/types.bal
+++ b/sql-ballerina/types.bal
@@ -378,10 +378,10 @@ class ResultIterator {
             return self.err;
         } else {
             record {}|Error? result;
-            if(self.customResultIterator is CustomResultIterator){
+            if (self.customResultIterator is CustomResultIterator) {
                 result = (<CustomResultIterator>self.customResultIterator).nextResult(self);
             }
-            else{
+            else {
                 result = nextResult(self);
             }
             if (result is record {}) {
@@ -416,7 +416,7 @@ class ResultIterator {
 # The custom result iterator object type that is used as a structure to define custom
 # result iterator classes in connector modules
 # 
-public type CustomResultIterator object{
+public type CustomResultIterator object {
     isolated function nextResult(ResultIterator iterator) returns record {}|Error?;
 };
 
@@ -797,7 +797,7 @@ public class ProcedureCallResult {
     #
     # + return - True if the next result is `queryResult`
     public isolated function getNextQueryResult() returns boolean|Error {
-        if(self.customProcedureCallResult is CustomProcedureCallResult){
+        if (self.customProcedureCallResult is CustomProcedureCallResult) {
             return (<CustomProcedureCallResult>self.customProcedureCallResult).getNextQueryResult(self);
         }
         return getNextQueryResult(self);


### PR DESCRIPTION
## Purpose

- To refactor `ballerina/sql` to support custom datatype handling for different database connector modules.
- Issue - [#879](https://github.com/ballerina-platform/ballerina-standard-library/issues/879)

## Approach

- Added custom object type `CustomTypedValue` to let connectors extend the the parameters to have custom types passed in an SQL query. The parameter value inside this object type is public, hence allows connectors to define parameter classes with the same structure.
    
- Added `CustomResultIterator` parameter to class `ResultIterator`. It allows passing a custom connector specific ballerina object that contains a custom `nextResult()` function. This custom `nextResult()` will call a connector specific `RecordIteratorUtils.nextResult()`. This enables the connector specific `nextResult()` to access a child class instance of the `ResultParameterProcessor`.
    
- Added `CustomProcedureCallResult` parameter to the class `ProcedureCallResult`. This enables `ProcedureCallResultUtils` java class to access connector specific `ResultParameterProcessor` in a similar passion as above.

- Changed the java class paths of `get()` methods in types.bal from `utils` to `nativeimpl`.
## Documentation
- [SQL Refactor Proposal](https://docs.google.com/document/d/1Xs8pPqEG4aSbGqX1a9C6J-rAjwIe6SmMx0PMkC34xfs/edit?usp=sharing)

## Related PRs
- #95, #94, #93, #92 , #91 , #87