### PR TITLE
Refactor RecordIteratorutils

### DIFF
--- a/sql-native/src/main/java/org/ballerinalang/sql/utils/RecordIteratorUtils.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/utils/RecordIteratorUtils.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/sql-native/src/main/java/org/ballerinalang/sql/utils/RecordIteratorUtils.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/utils/RecordIteratorUtils.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -29,6 +29,7 @@ import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 import org.ballerinalang.sql.Constants;
 import org.ballerinalang.sql.exception.ApplicationError;
+import org.ballerinalang.sql.parameterprocessor.ResultParameterProcessor;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -52,7 +53,6 @@ import java.util.TimeZone;
 
 import static io.ballerina.runtime.api.utils.StringUtils.fromString;
 import static org.ballerinalang.sql.utils.Utils.cleanUpConnection;
-import static org.ballerinalang.sql.utils.Utils.convert;
 import static org.ballerinalang.sql.utils.Utils.getString;
 
 /**
@@ -65,6 +65,11 @@ public class RecordIteratorUtils {
             .getInstance(TimeZone.getTimeZone(Constants.TIMEZONE_UTC.getValue()));
 
     public static Object nextResult(BObject recordIterator) {
+        ResultParameterProcessor resultParameterProcessor = ResultParameterProcessor.getInstance();
+        return nextResult(recordIterator, resultParameterProcessor);
+    }
+
+    public static Object nextResult(BObject recordIterator, ResultParameterProcessor resultParameterProcessor) {
         ResultSet resultSet = (ResultSet) recordIterator.getNativeData(Constants.RESULT_SET_NATIVE_DATA_FIELD);
         try {
             if (resultSet.next()) {
@@ -76,7 +81,7 @@ public class RecordIteratorUtils {
                 for (int i = 0; i < columnDefinitions.size(); i++) {
                     ColumnDefinition columnDefinition = columnDefinitions.get(i);
                     bStruct.put(fromString(columnDefinition.getBallerinaFieldName()),
-                            getResult(resultSet, i + 1, columnDefinition));
+                            getResult(resultSet, i + 1, columnDefinition, resultParameterProcessor));
                 }
                 return bStruct;
             } else {
@@ -93,123 +98,130 @@ public class RecordIteratorUtils {
         }
     }
 
-    private static Object getResult(ResultSet resultSet, int columnIndex, ColumnDefinition columnDefinition)
+    private static Object getResult(ResultSet resultSet, int columnIndex, ColumnDefinition columnDefinition,
+                    ResultParameterProcessor resultParameterProcessor)
             throws SQLException, ApplicationError, IOException {
         int sqlType = columnDefinition.getSqlType();
         Type ballerinaType = columnDefinition.getBallerinaType();
         switch (sqlType) {
             case Types.ARRAY:
-                return convert(resultSet.getArray(columnIndex), sqlType, ballerinaType);
+                return resultParameterProcessor.convert(resultSet.getArray(columnIndex), sqlType, ballerinaType);
             case Types.CHAR:
             case Types.VARCHAR:
             case Types.LONGVARCHAR:
             case Types.NCHAR:
             case Types.NVARCHAR:
             case Types.LONGNVARCHAR:
-                return convert(resultSet.getString(columnIndex), sqlType, ballerinaType);
+                return resultParameterProcessor.convert(resultSet.getString(columnIndex), sqlType, ballerinaType);
             case Types.BINARY:
             case Types.VARBINARY:
             case Types.LONGVARBINARY:
                 if (ballerinaType.getTag() == TypeTags.STRING_TAG) {
-                    return convert(resultSet.getString(columnIndex), sqlType, ballerinaType,
+                    return resultParameterProcessor.convert(resultSet.getString(columnIndex), sqlType, ballerinaType,
                             columnDefinition.getSqlName());
                 } else {
-                    return convert(resultSet.getBytes(columnIndex), sqlType, ballerinaType,
+                    return resultParameterProcessor.convert(resultSet.getBytes(columnIndex), sqlType, ballerinaType,
                             columnDefinition.getSqlName());
                 }
             case Types.BLOB:
-                return convert(resultSet.getBlob(columnIndex), sqlType, ballerinaType);
+                return resultParameterProcessor.convert(resultSet.getBlob(columnIndex), sqlType, ballerinaType);
             case Types.CLOB:
                 String clobValue = getString(resultSet.getClob(columnIndex));
-                return convert(clobValue, sqlType, ballerinaType);
+                return resultParameterProcessor.convert(clobValue, sqlType, ballerinaType);
             case Types.NCLOB:
                 String nClobValue = getString(resultSet.getNClob(columnIndex));
-                return convert(nClobValue, sqlType, ballerinaType);
+                return resultParameterProcessor.convert(nClobValue, sqlType, ballerinaType);
             case Types.DATE:
                 Date date = resultSet.getDate(columnIndex, calendar);
-                return convert(date, sqlType, ballerinaType);
+                return resultParameterProcessor.convert(date, sqlType, ballerinaType);
             case Types.TIME:
                 Time time = resultSet.getTime(columnIndex, calendar);
-                return convert(time, sqlType, ballerinaType);
+                return resultParameterProcessor.convert(time, sqlType, ballerinaType);
             case Types.TIME_WITH_TIMEZONE:
                 try {
                     time = resultSet.getTime(columnIndex, calendar);
-                    return convert(time, sqlType, ballerinaType);
+                    return resultParameterProcessor.convert(time, sqlType, ballerinaType);
                 } catch (SQLException ex) {
                     //Some database drivers do not support getTime operation,
                     // therefore falling back to getObject method.
                     OffsetTime offsetTime = resultSet.getObject(columnIndex, OffsetTime.class);
-                    return convert(Time.valueOf(offsetTime.toLocalTime()), sqlType, ballerinaType);
+                    return resultParameterProcessor.convert(Time.valueOf(offsetTime.toLocalTime()), 
+                           sqlType, ballerinaType);
                 }
             case Types.TIMESTAMP:
                 Timestamp timestamp = resultSet.getTimestamp(columnIndex, calendar);
-                return convert(timestamp, sqlType, ballerinaType);
+                return resultParameterProcessor.convert(timestamp, sqlType, ballerinaType);
             case Types.TIMESTAMP_WITH_TIMEZONE:
                 try {
                     timestamp = resultSet.getTimestamp(columnIndex, calendar);
-                    return convert(timestamp, sqlType, ballerinaType);
+                    return resultParameterProcessor.convert(timestamp, sqlType, ballerinaType);
                 } catch (SQLException ex) {
                     //Some database drivers do not support getTimestamp operation,
                     // therefore falling back to getObject method.
                     OffsetDateTime offsetDateTime = resultSet.getObject(columnIndex, OffsetDateTime.class);
-                    return convert(Timestamp.valueOf(offsetDateTime.toLocalDateTime()), sqlType, ballerinaType);
+                    return resultParameterProcessor.convert(Timestamp.valueOf(offsetDateTime.toLocalDateTime()),
+                            sqlType, ballerinaType);
                 }
             case Types.ROWID:
-                return convert(resultSet.getRowId(columnIndex).getBytes(), sqlType, ballerinaType, "SQL RowID");
+                return resultParameterProcessor.convert(resultSet.getRowId(columnIndex).getBytes(), sqlType, 
+                            ballerinaType, "SQL RowID");
             case Types.TINYINT:
             case Types.SMALLINT:
                 long iValue = resultSet.getInt(columnIndex);
-                return convert(iValue, sqlType, ballerinaType, resultSet.wasNull());
+                return resultParameterProcessor.convert(iValue, sqlType, ballerinaType, resultSet.wasNull());
             case Types.INTEGER:
             case Types.BIGINT:
                 long lValue = resultSet.getLong(columnIndex);
-                return convert(lValue, sqlType, ballerinaType, resultSet.wasNull());
+                return resultParameterProcessor.convert(lValue, sqlType, ballerinaType, resultSet.wasNull());
             case Types.REAL:
             case Types.FLOAT:
                 double fValue = resultSet.getFloat(columnIndex);
-                return convert(fValue, sqlType, ballerinaType, resultSet.wasNull());
+                return resultParameterProcessor.convert(fValue, sqlType, ballerinaType, resultSet.wasNull());
             case Types.DOUBLE:
                 double dValue = resultSet.getDouble(columnIndex);
-                return convert(dValue, sqlType, ballerinaType, resultSet.wasNull());
+                return resultParameterProcessor.convert(dValue, sqlType, ballerinaType, resultSet.wasNull());
             case Types.NUMERIC:
             case Types.DECIMAL:
                 BigDecimal decimalValue = resultSet.getBigDecimal(columnIndex);
-                return convert(decimalValue, sqlType, ballerinaType, resultSet.wasNull());
+                return resultParameterProcessor.convert(decimalValue, sqlType, ballerinaType, resultSet.wasNull());
             case Types.BIT:
             case Types.BOOLEAN:
                 boolean boolValue = resultSet.getBoolean(columnIndex);
-                return convert(boolValue, sqlType, ballerinaType, resultSet.wasNull());
+                return resultParameterProcessor.convert(boolValue, sqlType, ballerinaType, resultSet.wasNull());
             case Types.REF:
             case Types.STRUCT:
                 Struct structData = (Struct) resultSet.getObject(columnIndex);
-                return convert(structData, sqlType, ballerinaType);
+                return resultParameterProcessor.convert(structData, sqlType, ballerinaType);
             case Types.SQLXML:
                 SQLXML sqlxml = resultSet.getSQLXML(columnIndex);
-                return convert(sqlxml, sqlType, ballerinaType);
+                return resultParameterProcessor.convert(sqlxml, sqlType, ballerinaType);
             default:
                 if (ballerinaType.getTag() == TypeTags.INT_TAG) {
-                    convert(resultSet.getInt(columnIndex), sqlType, ballerinaType, resultSet.wasNull());
+                    resultParameterProcessor.convert(resultSet.getInt(columnIndex), sqlType, ballerinaType,
+                             resultSet.wasNull());
                 } else if (ballerinaType.getTag() == TypeTags.STRING_TAG
                         || ballerinaType.getTag() == TypeTags.ANY_TAG
                         || ballerinaType.getTag() == TypeTags.ANYDATA_TAG) {
-                    return convert(resultSet.getString(columnIndex), sqlType, ballerinaType);
+                    return resultParameterProcessor.convert(resultSet.getString(columnIndex), sqlType, ballerinaType);
                 } else if (ballerinaType.getTag() == TypeTags.BOOLEAN_TAG) {
-                    return convert(resultSet.getBoolean(columnIndex),
+                    return resultParameterProcessor.convert(resultSet.getBoolean(columnIndex),
                             sqlType, ballerinaType, resultSet.wasNull());
                 } else if (ballerinaType.getTag() == TypeTags.ARRAY_TAG &&
                         ((ArrayType) ballerinaType).getElementType().getTag() == TypeTags.BYTE_TAG) {
-                    return convert(resultSet.getBytes(columnIndex), sqlType, ballerinaType,
+                    return resultParameterProcessor.convert(resultSet.getBytes(columnIndex), sqlType, ballerinaType,
                             columnDefinition.getSqlName());
                 } else if (ballerinaType.getTag() == TypeTags.FLOAT_TAG) {
-                    return convert(resultSet.getDouble(columnIndex), sqlType, ballerinaType,
+                    return resultParameterProcessor.convert(resultSet.getDouble(columnIndex), sqlType, ballerinaType,
                             resultSet.wasNull());
                 } else if (ballerinaType.getTag() == TypeTags.DECIMAL_TAG) {
-                    return convert(resultSet.getBigDecimal(columnIndex), sqlType, ballerinaType,
+                    return resultParameterProcessor.convert(resultSet.getBigDecimal(columnIndex), sqlType,
+                            ballerinaType,
                             resultSet.wasNull());
                 } else if (ballerinaType.getTag() == TypeTags.XML_TAG) {
-                    return convert(resultSet.getSQLXML(columnIndex), sqlType, ballerinaType);
+                    return resultParameterProcessor.convert(resultSet.getSQLXML(columnIndex), sqlType, ballerinaType);
                 } else if (ballerinaType.getTag() == TypeTags.JSON_TAG) {
-                    String jsonString = convert(resultSet.getString(columnIndex), sqlType, ballerinaType)
+                    String jsonString = resultParameterProcessor.convert(resultSet.getString(columnIndex), sqlType,
+                            ballerinaType)
                             .getValue();
                     Reader reader = new StringReader(jsonString);
                     try {
@@ -218,7 +230,7 @@ public class RecordIteratorUtils {
                         throw new ApplicationError("Error while converting to JSON type. " + e.getDetails());
                     }
                 }
-                throw new ApplicationError("Unsupported SQL type " + columnDefinition.getSqlName());
+                return resultParameterProcessor.getCustomResult(resultSet, columnIndex, columnDefinition);
         }
     }
 


### PR DESCRIPTION
## Purpose

- Refactor `RecordIteratorutils` as a part of refactoring `ballerina/sql` to support custom datatype handling for different database connector modules.

## Goals

- Close issues [#887](https://github.com/ballerina-platform/ballerina-standard-library/issues/887)

## Approach

- Overload `nextResult()` method. One `nextResult()` includes `ResultParameterHelper` as a parameter. The other gets the sql module's `ResultParameterHelper` singleton instance.

- Change the imports for `convert()` as it has been moved from `Utils` to `ResultParameterHelper` class.

## Documentation
- [SQL Refactor Proposal](https://docs.google.com/document/d/1Xs8pPqEG4aSbGqX1a9C6J-rAjwIe6SmMx0PMkC34xfs/edit?usp=sharing)

## Related PRs
- #91 , #92 , #87 