### PR TITLE
Re Changed Years in nativeimpl

### DIFF
--- a/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/CallProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/CallProcessor.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/ClientProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/ClientProcessor.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/ExecuteProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/ExecuteProcessor.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/OutParameterProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/OutParameterProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/QueryProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/QueryProcessor.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except


### PR DESCRIPTION
## Purpose
> Change the license year in the file header of nativeimpl package classes to 2020 from 2021. It is because they are originally created as utils package classes in 2020 and renamed.