### PR TITLE
Rename Overloaded "convert" Methods in ResultParameterProcessor

### DIFF
--- a/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/OutParameterProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/OutParameterProcessor.java
@@ -71,38 +71,38 @@ public class OutParameterProcessor {
                 case Types.NCHAR:
                 case Types.NVARCHAR:
                 case Types.LONGNVARCHAR:
-                    return resultParameterProcessor.convert((String) value, sqlType, ballerinaType);
+                    return resultParameterProcessor.convertChar((String) value, sqlType, ballerinaType);
                 case Types.BINARY:
                 case Types.VARBINARY:
                 case Types.LONGVARBINARY:
                     if (ballerinaType.getTag() == TypeTags.STRING_TAG) {
-                        return resultParameterProcessor.convert((String) value, sqlType, ballerinaType);
+                        return resultParameterProcessor.convertChar((String) value, sqlType, ballerinaType);
                     } else {
-                        return resultParameterProcessor.convert(
+                        return resultParameterProcessor.convertByteArray(
                                 ((String) value).getBytes(Charset.defaultCharset()), sqlType, ballerinaType,
                                 JDBCType.valueOf(sqlType).getName()
                         );
                     }
                 case Types.ARRAY:
-                    return resultParameterProcessor.convert((Array) value, sqlType, ballerinaType);
+                    return resultParameterProcessor.convertArray((Array) value, sqlType, ballerinaType);
                 case Types.BLOB:
-                    return resultParameterProcessor.convert((Blob) value, sqlType, ballerinaType);
+                    return resultParameterProcessor.convertBlob((Blob) value, sqlType, ballerinaType);
                 case Types.CLOB:
                     String clobValue = getString((Clob) value);
-                    return resultParameterProcessor.convert(clobValue, sqlType, ballerinaType);
+                    return resultParameterProcessor.convertChar(clobValue, sqlType, ballerinaType);
                 case Types.NCLOB:
                     String nClobValue = getString((NClob) value);
-                    return resultParameterProcessor.convert(nClobValue, sqlType, ballerinaType);
+                    return resultParameterProcessor.convertChar(nClobValue, sqlType, ballerinaType);
                 case Types.DATE:
-                    return resultParameterProcessor.convert((Date) value, sqlType, ballerinaType);
+                    return resultParameterProcessor.convertDate((Date) value, sqlType, ballerinaType);
                 case Types.TIME:
                 case Types.TIME_WITH_TIMEZONE:
-                    return resultParameterProcessor.convert((Time) value, sqlType, ballerinaType);
+                    return resultParameterProcessor.convertDate((Time) value, sqlType, ballerinaType);
                 case Types.TIMESTAMP:
                 case Types.TIMESTAMP_WITH_TIMEZONE:
-                    return resultParameterProcessor.convert((Timestamp) value, sqlType, ballerinaType);
+                    return resultParameterProcessor.convertDate((Timestamp) value, sqlType, ballerinaType);
                 case Types.ROWID:
-                    return resultParameterProcessor.convert(
+                    return resultParameterProcessor.convertByteArray(
                             ((RowId) value).getBytes(), sqlType, ballerinaType, "SQL RowID"
                     );
                 case Types.TINYINT:
@@ -110,41 +110,41 @@ public class OutParameterProcessor {
                     if (value == null) {
                         return null;
                     }
-                    return resultParameterProcessor.convert((int) value, sqlType, ballerinaType, false);
+                    return resultParameterProcessor.convertInteger((int) value, sqlType, ballerinaType, false);
                 case Types.INTEGER:
                 case Types.BIGINT:
                     if (value == null) {
                         return null;
                     }
-                    return resultParameterProcessor.convert((long) value, sqlType, ballerinaType, false);
+                    return resultParameterProcessor.convertInteger((long) value, sqlType, ballerinaType, false);
                 case Types.REAL:
                 case Types.FLOAT:
                     if (value == null) {
                         return null;
                     }
-                    return resultParameterProcessor.convert((float) value, sqlType, ballerinaType, false);
+                    return resultParameterProcessor.convertDouble((float) value, sqlType, ballerinaType, false);
                 case Types.DOUBLE:
                     if (value == null) {
                         return null;
                     }
-                    return resultParameterProcessor.convert((double) value, sqlType, ballerinaType, false);
+                    return resultParameterProcessor.convertDouble((double) value, sqlType, ballerinaType, false);
                 case Types.NUMERIC:
                 case Types.DECIMAL:
                     if (value == null) {
                         return null;
                     }
-                    return resultParameterProcessor.convert((BigDecimal) value, sqlType, ballerinaType, false);
+                    return resultParameterProcessor.convertDecimal((BigDecimal) value, sqlType, ballerinaType, false);
                 case Types.BIT:
                 case Types.BOOLEAN:
                     if (value == null) {
                         return null;
                     }
-                    return resultParameterProcessor.convert((boolean) value, sqlType, ballerinaType, false);
+                    return resultParameterProcessor.convertBoolean((boolean) value, sqlType, ballerinaType, false);
                 case Types.REF:
                 case Types.STRUCT:
-                    return resultParameterProcessor.convert((Struct) value, sqlType, ballerinaType);
+                    return resultParameterProcessor.convertStruct((Struct) value, sqlType, ballerinaType);
                 case Types.SQLXML:
-                    return resultParameterProcessor.convert((SQLXML) value, sqlType, ballerinaType);
+                    return resultParameterProcessor.convertXml((SQLXML) value, sqlType, ballerinaType);
                 default:
                     return resultParameterProcessor.getCustomOutParameters(value, sqlType, ballerinaType);
             }

--- a/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/AbstractResultParameterProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/AbstractResultParameterProcessor.java
@@ -55,29 +55,37 @@ public abstract class AbstractResultParameterProcessor {
     protected abstract void createUserDefinedTypeSubtype(Field internalField, StructureType structType)
             throws ApplicationError;
 
-    protected abstract BArray convert(Array array, int sqlType, Type type) throws SQLException, ApplicationError;
+    protected abstract BArray convertArray(Array array, int sqlType, Type type)
+            throws SQLException, ApplicationError;
 
-    protected abstract BString convert(String value, int sqlType, Type type) throws ApplicationError;
+    protected abstract BString convertChar(String value, int sqlType, Type type)
+            throws ApplicationError;
 
-    protected abstract Object convert(String value, int sqlType, Type type, String sqlTypeName) throws ApplicationError;
+    protected abstract Object convertChar(String value, int sqlType, Type type, String sqlTypeName)
+            throws ApplicationError;
 
-    protected abstract Object convert(byte[] value, int sqlType, Type type, String sqlTypeName) throws ApplicationError;
+    protected abstract Object convertByteArray(byte[] value, int sqlType, Type type, String sqlTypeName)
+            throws ApplicationError;
 
-    protected abstract Object convert(long value, int sqlType, Type type, boolean isNull) throws ApplicationError;
+    protected abstract Object convertInteger(long value, int sqlType, Type type, boolean isNull)
+            throws ApplicationError;
 
-    protected abstract Object convert(double value, int sqlType, Type type, boolean isNull) throws ApplicationError;
+    protected abstract Object convertDouble(double value, int sqlType, Type type, boolean isNull)
+            throws ApplicationError;
 
-    protected abstract Object convert(BigDecimal value, int sqlType, Type type, boolean isNull) throws ApplicationError;
+    protected abstract Object convertDecimal(BigDecimal value, int sqlType, Type type, boolean isNull)
+            throws ApplicationError;
 
-    protected abstract Object convert(Blob value, int sqlType, Type type) throws ApplicationError, SQLException;
+    protected abstract Object convertBlob(Blob value, int sqlType, Type type) throws ApplicationError, SQLException;
 
-    protected abstract Object convert(java.util.Date date, int sqlType, Type type) throws ApplicationError;
+    protected abstract Object convertDate(java.util.Date date, int sqlType, Type type) throws ApplicationError;
 
-    protected abstract Object convert(boolean value, int sqlType, Type type, boolean isNull) throws ApplicationError;
+    protected abstract Object convertBoolean(boolean value, int sqlType, Type type, boolean isNull)
+            throws ApplicationError;
 
-    protected abstract Object convert(Struct value, int sqlType, Type type) throws ApplicationError;
+    protected abstract Object convertStruct(Struct value, int sqlType, Type type) throws ApplicationError;
 
-    protected abstract Object convert(SQLXML value, int sqlType, Type type) throws ApplicationError, SQLException;
+    protected abstract Object convertXml(SQLXML value, int sqlType, Type type) throws ApplicationError, SQLException;
 
     protected abstract void populateChar(CallableStatement statement, BObject parameter, int paramIndex)
             throws SQLException;

--- a/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/DefaultResultParameterProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/DefaultResultParameterProcessor.java
@@ -312,7 +312,7 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
     }
 
     @Override
-    public BArray convert(Array array, int sqlType, Type type) throws SQLException, ApplicationError {
+    public BArray convertArray(Array array, int sqlType, Type type) throws SQLException, ApplicationError {
         if (array != null) {
             Utils.validatedInvalidFieldAssignment(sqlType, type, "SQL Array");
             Object[] dataArray = (Object[]) array.getArray();
@@ -338,20 +338,20 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
     }
 
     @Override
-    public BString convert(String value, int sqlType, Type type) throws ApplicationError {
+    public BString convertChar(String value, int sqlType, Type type) throws ApplicationError {
         Utils.validatedInvalidFieldAssignment(sqlType, type, "SQL String");
         return fromString(value);
     }
 
     @Override
-    public Object convert(
+    public Object convertChar(
             String value, int sqlType, Type type, String sqlTypeName) throws ApplicationError {
         Utils.validatedInvalidFieldAssignment(sqlType, type, sqlTypeName);
         return fromString(value);
     }
 
     @Override
-    public Object convert(byte[] value, int sqlType, Type type, String sqlTypeName) throws ApplicationError {
+    public Object convertByteArray(byte[] value, int sqlType, Type type, String sqlTypeName) throws ApplicationError {
         if (value != null) {
             return ValueCreator.createArrayValue(value);
         } else {
@@ -360,7 +360,7 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
     }
 
     @Override
-    public Object convert(long value, int sqlType, Type type, boolean isNull) throws ApplicationError {
+    public Object convertInteger(long value, int sqlType, Type type, boolean isNull) throws ApplicationError {
         Utils.validatedInvalidFieldAssignment(sqlType, type, "SQL long or integer");
         if (isNull) {
             return null;
@@ -373,7 +373,7 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
     }
 
     @Override
-    public Object convert(double value, int sqlType, Type type, boolean isNull) throws ApplicationError {
+    public Object convertDouble(double value, int sqlType, Type type, boolean isNull) throws ApplicationError {
         Utils.validatedInvalidFieldAssignment(sqlType, type, "SQL double or float");
         if (isNull) {
             return null;
@@ -386,7 +386,7 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
     }
 
     @Override
-    public Object convert(BigDecimal value, int sqlType, Type type, boolean isNull) throws ApplicationError {
+    public Object convertDecimal(BigDecimal value, int sqlType, Type type, boolean isNull) throws ApplicationError {
         Utils.validatedInvalidFieldAssignment(sqlType, type, "SQL decimal or real");
         if (isNull) {
             return null;
@@ -399,7 +399,7 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
     }
 
     @Override
-    public Object convert(Blob value, int sqlType, Type type) throws ApplicationError, SQLException {
+    public Object convertBlob(Blob value, int sqlType, Type type) throws ApplicationError, SQLException {
         Utils.validatedInvalidFieldAssignment(sqlType, type, "SQL Blob");
         if (value != null) {
             return ValueCreator.createArrayValue(value.getBytes(1L, (int) value.length()));
@@ -409,7 +409,7 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
     }
 
     @Override
-    public Object convert(java.util.Date date, int sqlType, Type type) throws ApplicationError {
+    public Object convertDate(java.util.Date date, int sqlType, Type type) throws ApplicationError {
         Utils.validatedInvalidFieldAssignment(sqlType, type, "SQL Date/Time");
         if (date != null) {
             switch (type.getTag()) {
@@ -426,7 +426,7 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
     }
 
     @Override
-    public Object convert(boolean value, int sqlType, Type type, boolean isNull) throws ApplicationError {
+    public Object convertBoolean(boolean value, int sqlType, Type type, boolean isNull) throws ApplicationError {
         Utils.validatedInvalidFieldAssignment(sqlType, type, "SQL Boolean");
         if (!isNull) {
             switch (type.getTag()) {
@@ -446,7 +446,7 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
     }
 
     @Override
-    public Object convert(Struct value, int sqlType, Type type) throws ApplicationError {
+    public Object convertStruct(Struct value, int sqlType, Type type) throws ApplicationError {
         Utils.validatedInvalidFieldAssignment(sqlType, type, "SQL Struct");
         if (value != null) {
             if (type instanceof RecordType) {
@@ -461,7 +461,7 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
     }
 
     @Override
-    public Object convert(SQLXML value, int sqlType, Type type) throws ApplicationError, SQLException {
+    public Object convertXml(SQLXML value, int sqlType, Type type) throws ApplicationError, SQLException {
         Utils.validatedInvalidFieldAssignment(sqlType, type, "SQL XML");
         if (value != null) {
             if (type instanceof BXml) {

--- a/sql-native/src/main/java/org/ballerinalang/sql/utils/RecordIteratorUtils.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/utils/RecordIteratorUtils.java
@@ -105,124 +105,125 @@ public class RecordIteratorUtils {
         Type ballerinaType = columnDefinition.getBallerinaType();
         switch (sqlType) {
             case Types.ARRAY:
-                return resultParameterProcessor.convert(resultSet.getArray(columnIndex), sqlType, ballerinaType);
+                return resultParameterProcessor.convertArray(resultSet.getArray(columnIndex), sqlType, ballerinaType);
             case Types.CHAR:
             case Types.VARCHAR:
             case Types.LONGVARCHAR:
             case Types.NCHAR:
             case Types.NVARCHAR:
             case Types.LONGNVARCHAR:
-                return resultParameterProcessor.convert(resultSet.getString(columnIndex), sqlType, ballerinaType);
+                return resultParameterProcessor.convertChar(resultSet.getString(columnIndex), sqlType, ballerinaType);
             case Types.BINARY:
             case Types.VARBINARY:
             case Types.LONGVARBINARY:
                 if (ballerinaType.getTag() == TypeTags.STRING_TAG) {
-                    return resultParameterProcessor.convert(resultSet.getString(columnIndex), sqlType, ballerinaType,
-                            columnDefinition.getSqlName());
+                    return resultParameterProcessor.convertChar(
+                            resultSet.getString(columnIndex), sqlType, ballerinaType, columnDefinition.getSqlName());
                 } else {
-                    return resultParameterProcessor.convert(resultSet.getBytes(columnIndex), sqlType, ballerinaType,
-                            columnDefinition.getSqlName());
+                    return resultParameterProcessor.convertByteArray(
+                            resultSet.getBytes(columnIndex), sqlType, ballerinaType, columnDefinition.getSqlName());
                 }
             case Types.BLOB:
-                return resultParameterProcessor.convert(resultSet.getBlob(columnIndex), sqlType, ballerinaType);
+                return resultParameterProcessor.convertBlob(resultSet.getBlob(columnIndex), sqlType, ballerinaType);
             case Types.CLOB:
                 String clobValue = getString(resultSet.getClob(columnIndex));
-                return resultParameterProcessor.convert(clobValue, sqlType, ballerinaType);
+                return resultParameterProcessor.convertChar(clobValue, sqlType, ballerinaType);
             case Types.NCLOB:
                 String nClobValue = getString(resultSet.getNClob(columnIndex));
-                return resultParameterProcessor.convert(nClobValue, sqlType, ballerinaType);
+                return resultParameterProcessor.convertChar(nClobValue, sqlType, ballerinaType);
             case Types.DATE:
                 Date date = resultSet.getDate(columnIndex, calendar);
-                return resultParameterProcessor.convert(date, sqlType, ballerinaType);
+                return resultParameterProcessor.convertDate(date, sqlType, ballerinaType);
             case Types.TIME:
                 Time time = resultSet.getTime(columnIndex, calendar);
-                return resultParameterProcessor.convert(time, sqlType, ballerinaType);
+                return resultParameterProcessor.convertDate(time, sqlType, ballerinaType);
             case Types.TIME_WITH_TIMEZONE:
                 try {
                     time = resultSet.getTime(columnIndex, calendar);
-                    return resultParameterProcessor.convert(time, sqlType, ballerinaType);
+                    return resultParameterProcessor.convertDate(time, sqlType, ballerinaType);
                 } catch (SQLException ex) {
                     //Some database drivers do not support getTime operation,
                     // therefore falling back to getObject method.
                     OffsetTime offsetTime = resultSet.getObject(columnIndex, OffsetTime.class);
-                    return resultParameterProcessor.convert(Time.valueOf(offsetTime.toLocalTime()), 
+                    return resultParameterProcessor.convertDate(Time.valueOf(offsetTime.toLocalTime()), 
                            sqlType, ballerinaType);
                 }
             case Types.TIMESTAMP:
                 Timestamp timestamp = resultSet.getTimestamp(columnIndex, calendar);
-                return resultParameterProcessor.convert(timestamp, sqlType, ballerinaType);
+                return resultParameterProcessor.convertDate(timestamp, sqlType, ballerinaType);
             case Types.TIMESTAMP_WITH_TIMEZONE:
                 try {
                     timestamp = resultSet.getTimestamp(columnIndex, calendar);
-                    return resultParameterProcessor.convert(timestamp, sqlType, ballerinaType);
+                    return resultParameterProcessor.convertDate(timestamp, sqlType, ballerinaType);
                 } catch (SQLException ex) {
                     //Some database drivers do not support getTimestamp operation,
                     // therefore falling back to getObject method.
                     OffsetDateTime offsetDateTime = resultSet.getObject(columnIndex, OffsetDateTime.class);
-                    return resultParameterProcessor.convert(Timestamp.valueOf(offsetDateTime.toLocalDateTime()),
+                    return resultParameterProcessor.convertDate(Timestamp.valueOf(offsetDateTime.toLocalDateTime()),
                             sqlType, ballerinaType);
                 }
             case Types.ROWID:
-                return resultParameterProcessor.convert(resultSet.getRowId(columnIndex).getBytes(), sqlType, 
+                return resultParameterProcessor.convertByteArray(resultSet.getRowId(columnIndex).getBytes(), sqlType, 
                             ballerinaType, "SQL RowID");
             case Types.TINYINT:
             case Types.SMALLINT:
                 long iValue = resultSet.getInt(columnIndex);
-                return resultParameterProcessor.convert(iValue, sqlType, ballerinaType, resultSet.wasNull());
+                return resultParameterProcessor.convertInteger(iValue, sqlType, ballerinaType, resultSet.wasNull());
             case Types.INTEGER:
             case Types.BIGINT:
                 long lValue = resultSet.getLong(columnIndex);
-                return resultParameterProcessor.convert(lValue, sqlType, ballerinaType, resultSet.wasNull());
+                return resultParameterProcessor.convertInteger(lValue, sqlType, ballerinaType, resultSet.wasNull());
             case Types.REAL:
             case Types.FLOAT:
                 double fValue = resultSet.getFloat(columnIndex);
-                return resultParameterProcessor.convert(fValue, sqlType, ballerinaType, resultSet.wasNull());
+                return resultParameterProcessor.convertDouble(fValue, sqlType, ballerinaType, resultSet.wasNull());
             case Types.DOUBLE:
                 double dValue = resultSet.getDouble(columnIndex);
-                return resultParameterProcessor.convert(dValue, sqlType, ballerinaType, resultSet.wasNull());
+                return resultParameterProcessor.convertDouble(dValue, sqlType, ballerinaType, resultSet.wasNull());
             case Types.NUMERIC:
             case Types.DECIMAL:
                 BigDecimal decimalValue = resultSet.getBigDecimal(columnIndex);
-                return resultParameterProcessor.convert(decimalValue, sqlType, ballerinaType, resultSet.wasNull());
+                return resultParameterProcessor.convertDecimal(
+                        decimalValue, sqlType, ballerinaType, resultSet.wasNull());
             case Types.BIT:
             case Types.BOOLEAN:
                 boolean boolValue = resultSet.getBoolean(columnIndex);
-                return resultParameterProcessor.convert(boolValue, sqlType, ballerinaType, resultSet.wasNull());
+                return resultParameterProcessor.convertBoolean(boolValue, sqlType, ballerinaType, resultSet.wasNull());
             case Types.REF:
             case Types.STRUCT:
                 Struct structData = (Struct) resultSet.getObject(columnIndex);
-                return resultParameterProcessor.convert(structData, sqlType, ballerinaType);
+                return resultParameterProcessor.convertStruct(structData, sqlType, ballerinaType);
             case Types.SQLXML:
                 SQLXML sqlxml = resultSet.getSQLXML(columnIndex);
-                return resultParameterProcessor.convert(sqlxml, sqlType, ballerinaType);
+                return resultParameterProcessor.convertXml(sqlxml, sqlType, ballerinaType);
             default:
                 if (ballerinaType.getTag() == TypeTags.INT_TAG) {
-                    resultParameterProcessor.convert(resultSet.getInt(columnIndex), sqlType, ballerinaType,
-                             resultSet.wasNull());
+                    resultParameterProcessor.convertInteger(
+                            resultSet.getInt(columnIndex), sqlType, ballerinaType, resultSet.wasNull());
                 } else if (ballerinaType.getTag() == TypeTags.STRING_TAG
                         || ballerinaType.getTag() == TypeTags.ANY_TAG
                         || ballerinaType.getTag() == TypeTags.ANYDATA_TAG) {
-                    return resultParameterProcessor.convert(resultSet.getString(columnIndex), sqlType, ballerinaType);
+                    return resultParameterProcessor.convertChar(
+                            resultSet.getString(columnIndex), sqlType, ballerinaType);
                 } else if (ballerinaType.getTag() == TypeTags.BOOLEAN_TAG) {
-                    return resultParameterProcessor.convert(resultSet.getBoolean(columnIndex),
-                            sqlType, ballerinaType, resultSet.wasNull());
+                    return resultParameterProcessor.convertBoolean(
+                            resultSet.getBoolean(columnIndex), sqlType, ballerinaType, resultSet.wasNull());
                 } else if (ballerinaType.getTag() == TypeTags.ARRAY_TAG &&
                         ((ArrayType) ballerinaType).getElementType().getTag() == TypeTags.BYTE_TAG) {
-                    return resultParameterProcessor.convert(resultSet.getBytes(columnIndex), sqlType, ballerinaType,
-                            columnDefinition.getSqlName());
+                    return resultParameterProcessor.convertByteArray(
+                            resultSet.getBytes(columnIndex), sqlType, ballerinaType, columnDefinition.getSqlName());
                 } else if (ballerinaType.getTag() == TypeTags.FLOAT_TAG) {
-                    return resultParameterProcessor.convert(resultSet.getDouble(columnIndex), sqlType, ballerinaType,
-                            resultSet.wasNull());
+                    return resultParameterProcessor.convertDouble(
+                            resultSet.getDouble(columnIndex), sqlType, ballerinaType, resultSet.wasNull());
                 } else if (ballerinaType.getTag() == TypeTags.DECIMAL_TAG) {
-                    return resultParameterProcessor.convert(resultSet.getBigDecimal(columnIndex), sqlType,
-                            ballerinaType,
-                            resultSet.wasNull());
+                    return resultParameterProcessor.convertDecimal(
+                            resultSet.getBigDecimal(columnIndex), sqlType, ballerinaType, resultSet.wasNull());
                 } else if (ballerinaType.getTag() == TypeTags.XML_TAG) {
-                    return resultParameterProcessor.convert(resultSet.getSQLXML(columnIndex), sqlType, ballerinaType);
+                    return resultParameterProcessor.convertXml(
+                            resultSet.getSQLXML(columnIndex), sqlType, ballerinaType);
                 } else if (ballerinaType.getTag() == TypeTags.JSON_TAG) {
-                    String jsonString = resultParameterProcessor.convert(resultSet.getString(columnIndex), sqlType,
-                            ballerinaType)
-                            .getValue();
+                    String jsonString = resultParameterProcessor.convertChar(
+                            resultSet.getString(columnIndex), sqlType, ballerinaType).getValue();
                     Reader reader = new StringReader(jsonString);
                     try {
                         return JsonUtils.parse(reader, JsonUtils.NonStringValueProcessingMode.FROM_JSON_STRING);


### PR DESCRIPTION
- Rename the convert methods based on the sql type that they are converting to ballerina types in `ConcreteResultParameterProcessor` and `AbstractResultParameterProcessor` and the method invocations.

- Fix the formatting issues due to changed names