### PR TITLE
Remove Ballerina Type Checks in Connection Init Options

### DIFF
--- a/sql-ballerina/types.bal
+++ b/sql-ballerina/types.bal
@@ -737,7 +737,7 @@ public type ParameterizedCallQuery object {
 #                          of the nextResult method. 
 # + err - Used to hold any error to be returned 
 # + isClosed - The boolean flag used to indicate that the result iterator is closed 
-class ResultIterator {
+public class ResultIterator {
     private boolean isClosed = false;
     private Error? err;
     public CustomResultIterator? customResultIterator;

--- a/sql-native/src/main/java/org/ballerinalang/sql/datasource/PoolKey.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/datasource/PoolKey.java
@@ -22,8 +22,10 @@ import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.TypeUtils;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BValue;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * The key that uniquely identifies a connection pool encapsulated by {@link SQLDatasource}.
@@ -66,29 +68,40 @@ public class PoolKey {
         for (Map.Entry<BString, ?> entry : options.entrySet()) {
             int keyHashCode = entry.getKey().hashCode();
             Object value = entry.getValue();
-            Type type = TypeUtils.getType(value);
-            int typeTag = type.getTag();
             int valueHashCode;
-            switch (typeTag) {
-                case TypeTags.STRING_TAG:
-                case TypeTags.DECIMAL_TAG:
-                    valueHashCode = value.hashCode();
-                    break;
-                case TypeTags.BYTE_TAG:
-                case TypeTags.INT_TAG:
-                    long longValue = (Long) value;
-                    valueHashCode = (int) (longValue ^ (longValue >>> 32));
-                    break;
-                case TypeTags.FLOAT_TAG:
-                    long longValueConvertedFromDouble = Double.doubleToLongBits((Double) value);
-                    valueHashCode = (int) (longValueConvertedFromDouble ^ (longValueConvertedFromDouble >>> 32));
-                    break;
-                case TypeTags.BOOLEAN_TAG:
-                    valueHashCode = ((Boolean) value ? 1 : 0);
-                    break;
-                default:
-                    throw new AssertionError("type " + type.getName() + " shouldn't have occurred");
+            Objects.requireNonNull(value, "type null shouldn't have occurred");
+            if (value instanceof BValue || value instanceof Number
+                     || value instanceof String || value instanceof Boolean) {
+                Type type = TypeUtils.getType(value);
+                int typeTag = type.getTag();
+                switch (typeTag) {
+                    case TypeTags.STRING_TAG:
+                    case TypeTags.DECIMAL_TAG:
+                        valueHashCode = value.hashCode();
+                        break;
+                    case TypeTags.BYTE_TAG:
+                    case TypeTags.INT_TAG:
+                        // Assert to convince spotbugs that it's a number
+                        assert value instanceof Number;
+                        long longValue = (Long) value;
+                        valueHashCode = (int) (longValue ^ (longValue >>> 32));
+                        break;
+                    case TypeTags.FLOAT_TAG:
+                        assert value instanceof Double;
+                        long longValueConvertedFromDouble = Double.doubleToLongBits((Double) value);
+                        valueHashCode = (int) (longValueConvertedFromDouble ^ (longValueConvertedFromDouble >>> 32));
+                        break;
+                    case TypeTags.BOOLEAN_TAG:
+                        assert value instanceof Boolean;
+                        valueHashCode = ((Boolean) value ? 1 : 0);
+                        break;
+                    default:
+                        throw new AssertionError("type " + type.getName() + " shouldn't have occurred");
+                }
+            } else {
+                valueHashCode = value.hashCode();
             }
+
             hashCode = hashCode + keyHashCode + valueHashCode;
         }
         return hashCode;

--- a/sql-native/src/main/java/org/ballerinalang/sql/datasource/PoolKey.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/datasource/PoolKey.java
@@ -81,7 +81,7 @@ public class PoolKey {
                         break;
                     case TypeTags.BYTE_TAG:
                     case TypeTags.INT_TAG:
-                        // Assert to convince spotbugs that it's a number
+                        // Assert to convince spotbugs that value is a number
                         assert value instanceof Number;
                         long longValue = (Long) value;
                         valueHashCode = (int) (longValue ^ (longValue >>> 32));

--- a/sql-native/src/main/java/org/ballerinalang/sql/datasource/SQLDatasource.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/datasource/SQLDatasource.java
@@ -20,9 +20,6 @@ package org.ballerinalang.sql.datasource;
 import com.atomikos.jdbc.AtomikosDataSourceBean;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import io.ballerina.runtime.api.TypeTags;
-import io.ballerina.runtime.api.types.Type;
-import io.ballerina.runtime.api.utils.TypeUtils;
 import io.ballerina.runtime.api.values.BDecimal;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
@@ -348,12 +345,7 @@ public class SQLDatasource {
             if (sqlDatasourceParams.options != null) {
                 BMap<BString, Object> optionMap = (BMap<BString, Object>) sqlDatasourceParams.options;
                 optionMap.entrySet().forEach(entry -> {
-                    if (isSupportedDbOptionType(entry.getValue())) {
-                        config.addDataSourceProperty(entry.getKey().getValue(), entry.getValue());
-                    } else {
-                        throw ErrorGenerator.getSQLApplicationError("unsupported type " + entry.getKey()
-                                + " for the db option");
-                    }
+                    config.addDataSourceProperty(entry.getKey().getValue(), entry.getValue());
                 });
             }
             hikariDataSource = new HikariDataSource(config);
@@ -399,12 +391,7 @@ public class SQLDatasource {
             if (sqlDatasourceParams.options != null) {
                 BMap<BString, Object> optionMap = (BMap<BString, Object>) sqlDatasourceParams.options;
                 optionMap.entrySet().forEach(entry -> {
-                    if (isSupportedDbOptionType(entry.getValue())) {
-                        xaProperties.setProperty(entry.getKey().getValue(), entry.getValue().toString());
-                    } else {
-                        throw ErrorGenerator.getSQLApplicationError("unsupported type " + entry.getKey()
-                                + " for the db option");
-                    }
+                    xaProperties.setProperty(entry.getKey().getValue(), entry.getValue().toString());
                 });
             }
 
@@ -416,18 +403,6 @@ public class SQLDatasource {
         } catch (Throwable t) {
             throw ErrorGenerator.getSQLApplicationError(buildErrorMessage(t));
         }
-    }
-
-    private static boolean isSupportedDbOptionType(Object value) {
-        boolean supported = false;
-        if (value != null) {
-            Type type = TypeUtils.getType(value);
-            int typeTag = type.getTag();
-            supported = (typeTag == TypeTags.STRING_TAG || typeTag == TypeTags.INT_TAG || typeTag == TypeTags.FLOAT_TAG
-                    || typeTag == TypeTags.BOOLEAN_TAG || typeTag == TypeTags.DECIMAL_TAG
-                    || typeTag == TypeTags.BYTE_TAG);
-        }
-        return supported;
     }
 
     private String buildErrorMessage (Throwable t) {

--- a/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/CallProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/CallProcessor.java
@@ -80,7 +80,7 @@ public class CallProcessor {
      * @param paramSQLString SQL string for the call statement
      * @param recordTypes type description of the result record                
      * @param statementParameterProcessor pre-processor of the statement
-     * @param resultParameterProcessor post-processeor of the result
+     * @param resultParameterProcessor post-processor of the result
      * @return procedure call result or error
      */
     public static Object nativeCall(BObject client, Object paramSQLString, BArray recordTypes, 

--- a/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/DefaultStatementParameterProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/DefaultStatementParameterProcessor.java
@@ -185,7 +185,7 @@ public class DefaultStatementParameterProcessor extends AbstractStatementParamet
         Object value = typedValue.get(Constants.TypedValueFields.VALUE);
         switch (sqlType) {
             case Constants.SqlTypes.VARCHAR:
-                setVarchar(preparedStatement, index, value.toString());
+                setVarchar(preparedStatement, index, value);
                 break;
             case Constants.SqlTypes.CHAR:
                 setChar(preparedStatement, index, value);


### PR DESCRIPTION
## Purpose
- In the make of `module-ballerinax-oracledb` the additional connection properties should be passed bundled inside a java Properties instance. This is due to oracle data-source exposing a limited no of properties as APIs and letting others to be passed in as a Properties instance. [Documentation](https://docs.oracle.com/cd/E16338_01/appdev.112/e13995/oracle/jdbc/pool/OracleDataSource.html#setConnectionProperties_java_util_Properties_). Therefore it is required to allow a Properties object inside connection initialization options.
- The module contains some bugs that hinder the implementation of connector modules.

## Tasks
- Removed ballerina type checks in the `datasource` package.
- Make Minor Fixes
    - Fix issue in call processor comment
    - Remove toString() of setVarchar invocation inside setSqlTypedParam
    - Make ResultIterator public in types.bal
