### PR TITLE
Fix RealValue datatype precision

### DIFF
--- a/sql-ballerina/tests/simple-params-query-test.bal
+++ b/sql-ballerina/tests/simple-params-query-test.bal
@@ -315,7 +315,6 @@ function queryTypeFloatDoubleParam() {
 }
 
 @test:Config {
-    enable: false,
     groups: ["query", "query-simple-params"]
 }
 function queryTypeRealDoubleParam() {

--- a/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/QueryProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/QueryProcessor.java
@@ -60,7 +60,7 @@ public class QueryProcessor {
      * @param paramSQLString SQL string of the query
      * @param recordType type description of the result record       
      * @param statementParameterProcessor pre-processor of the statement
-     * @param resultParameterProcessor post-processeor of the result
+     * @param resultParameterProcessor post-processor of the result
      * @return result stream or error
      */
     public static BStream nativeQuery(

--- a/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/DefaultStatementParameterProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/DefaultStatementParameterProcessor.java
@@ -439,20 +439,6 @@ public class DefaultStatementParameterProcessor extends AbstractStatementParamet
         }
     }
 
-    private void setFloatAndReal(PreparedStatement preparedStatement, String sqlType, int index, Object value)
-            throws SQLException, ApplicationError {
-        if (value == null) {
-            preparedStatement.setNull(index, Types.FLOAT);
-        } else if (value instanceof Double || value instanceof Long ||
-                value instanceof Float || value instanceof Integer) {
-            preparedStatement.setFloat(index, ((Number) value).floatValue());
-        } else if (value instanceof BDecimal) {
-            preparedStatement.setFloat(index, ((BDecimal) value).decimalValue().floatValue());
-        } else {
-            throw throwInvalidParameterError(value, sqlType);
-        }
-    }
-
     private void setNumericAndDecimal(PreparedStatement preparedStatement, String sqlType, int index, Object value)
             throws SQLException, ApplicationError {
         if (value == null) {
@@ -720,13 +706,32 @@ public class DefaultStatementParameterProcessor extends AbstractStatementParamet
     @Override
     protected void setFloat(PreparedStatement preparedStatement, String sqlType, int index, Object value)
             throws SQLException, ApplicationError {
-        setFloatAndReal(preparedStatement, sqlType, index, value);
+        if (value == null) {
+            preparedStatement.setNull(index, Types.FLOAT);
+        } else if (value instanceof Double || value instanceof Long ||
+                value instanceof Float || value instanceof Integer) {
+            preparedStatement.setFloat(index, ((Number) value).floatValue());
+        } else if (value instanceof BDecimal) {
+            preparedStatement.setFloat(index, ((BDecimal) value).decimalValue().floatValue());
+        } else {
+            throw throwInvalidParameterError(value, sqlType);
+        }
     }
 
     @Override
     protected void setReal(PreparedStatement preparedStatement, String sqlType, int index, Object value)
             throws SQLException, ApplicationError {
-        setFloatAndReal(preparedStatement, sqlType, index, value);
+        if (value == null) {
+            preparedStatement.setNull(index, Types.FLOAT);
+        } else if (value instanceof Double) {
+            preparedStatement.setDouble(index, ((Number) value).doubleValue());
+        } else if (value instanceof Long || value instanceof Float || value instanceof Integer) {
+            preparedStatement.setFloat(index, ((Number) value).floatValue());
+        } else if (value instanceof BDecimal) {
+            preparedStatement.setFloat(index, ((BDecimal) value).decimalValue().floatValue());
+        } else {
+            throw throwInvalidParameterError(value, sqlType);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Purpose
> $Subject and enable RealValue test case.
Fixes: [#8](https://github.com/ballerina-platform/ballerina-standard-library/issues/8)

## Goals
> change the set method of preparedStatement from setFloat to setDouble for double value in RealType.
