### PR TITLE
Add seperate Methods for Xml and Binary Operations

### DIFF
--- a/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/OutParameterProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/OutParameterProcessor.java
@@ -18,7 +18,6 @@
 
 package org.ballerinalang.sql.nativeimpl;
 
-import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BTypedesc;
@@ -29,12 +28,10 @@ import org.ballerinalang.sql.utils.ErrorGenerator;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.nio.charset.Charset;
 import java.sql.Array;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Date;
-import java.sql.JDBCType;
 import java.sql.NClob;
 import java.sql.RowId;
 import java.sql.SQLException;
@@ -78,14 +75,7 @@ public class OutParameterProcessor {
                 case Types.BINARY:
                 case Types.VARBINARY:
                 case Types.LONGVARBINARY:
-                    if (ballerinaType.getTag() == TypeTags.STRING_TAG) {
-                        return resultParameterProcessor.convertChar((String) value, sqlType, ballerinaType);
-                    } else {
-                        return resultParameterProcessor.convertByteArray(
-                                ((String) value).getBytes(Charset.defaultCharset()), sqlType, ballerinaType,
-                                JDBCType.valueOf(sqlType).getName()
-                        );
-                    }
+                    return resultParameterProcessor.convertBinary(value, sqlType, ballerinaType);
                 case Types.ARRAY:
                     return resultParameterProcessor.convertArray((Array) value, sqlType, ballerinaType);
                 case Types.BLOB:

--- a/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/AbstractResultParameterProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/AbstractResultParameterProcessor.java
@@ -83,6 +83,8 @@ public abstract class AbstractResultParameterProcessor {
     protected abstract Object convertBoolean(boolean value, int sqlType, Type type, boolean isNull)
             throws ApplicationError;
 
+    public abstract Object convertBinary(Object value, int sqlType, Type ballerinaType) throws ApplicationError; 
+
     protected abstract Object convertStruct(Struct value, int sqlType, Type type) throws ApplicationError;
 
     protected abstract Object convertXml(SQLXML value, int sqlType, Type type) throws ApplicationError, SQLException;

--- a/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/DefaultResultParameterProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/DefaultResultParameterProcessor.java
@@ -42,10 +42,12 @@ import org.ballerinalang.sql.utils.ModuleUtils;
 import org.ballerinalang.sql.utils.Utils;
 
 import java.math.BigDecimal;
+import java.nio.charset.Charset;
 import java.sql.Array;
 import java.sql.Blob;
 import java.sql.CallableStatement;
 import java.sql.Connection;
+import java.sql.JDBCType;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLXML;
@@ -336,6 +338,17 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
             return ValueCreator.createArrayValue(value);
         } else {
             return null;
+        }
+    }
+
+    @Override
+    public Object convertBinary(Object value, int sqlType, Type ballerinaType) throws ApplicationError {
+        if (ballerinaType.getTag() == TypeTags.STRING_TAG) {
+            return convertChar((String) value, sqlType, ballerinaType);
+        } else {
+            return convertByteArray(((String) value).getBytes(Charset.defaultCharset()), sqlType, ballerinaType,
+                    JDBCType.valueOf(sqlType).getName()
+            );
         }
     }
 

--- a/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/DefaultStatementParameterProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/DefaultStatementParameterProcessor.java
@@ -393,11 +393,15 @@ public class DefaultStatementParameterProcessor extends AbstractStatementParamet
                         objectValue.getType().getQualifiedName() + " in column index: " + index);
             }
         } else if (object instanceof BXml) {
-            preparedStatement.setObject(index, ((BXml) object).getTextValue(), Types.SQLXML);
+            setXml(preparedStatement, index, (BXml) object);
             return Types.SQLXML;
         } else {
             throw new ApplicationError("Unsupported type passed in column index: " + index);
         }
+    }
+
+    protected void setXml(PreparedStatement preparedStatement, int index, BXml value) throws SQLException {
+        preparedStatement.setObject(index, value.getTextValue(), Types.SQLXML);
     }
 
     private void setString(PreparedStatement preparedStatement, int index, Object value)


### PR DESCRIPTION
Add seperate Methods for Xml and Binary Operations
Move `ConvertBinary` method from `OutParameterProcessor` to `ResultParameterProcessor`.
Create a seperate Method `setXml` in `StatementParameterProcessor` Class.