### PR TITLE
Update Convert Timestamp Methods to use time:Civil

### DIFF
--- a/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/DefaultResultParameterProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/DefaultResultParameterProcessor.java
@@ -551,7 +551,9 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
                     return fromString(timestamp.toString());
                 case TypeTags.OBJECT_TYPE_TAG:
                 case TypeTags.RECORD_TYPE_TAG:
-                    if (type.getName().equalsIgnoreCase(Constants.SqlTypes.DATETIME)
+                    if ((type.getName().equalsIgnoreCase(Constants.SqlTypes.DATETIME)
+                            || type.getName().
+                            equalsIgnoreCase(org.ballerinalang.stdlib.time.util.Constants.CIVIL_RECORD))
                             && timestamp instanceof Timestamp) {
                         LocalDateTime dateTimeObj = ((Timestamp) timestamp).toLocalDateTime();
                         BMap<BString, Object> civilMap = ValueCreator.createRecordValue(
@@ -595,7 +597,9 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
                     return fromString(offsetDateTime.toString());
                 case TypeTags.OBJECT_TYPE_TAG:
                 case TypeTags.RECORD_TYPE_TAG:
-                    if (type.getName().equalsIgnoreCase(Constants.SqlTypes.DATETIME)) {
+                    if (type.getName().equalsIgnoreCase(Constants.SqlTypes.DATETIME)
+                            || type.getName().
+                            equalsIgnoreCase(org.ballerinalang.stdlib.time.util.Constants.CIVIL_RECORD)) {
                         BMap<BString, Object> civilMap = ValueCreator.createRecordValue(
                                 org.ballerinalang.stdlib.time.util.ModuleUtils.getModule(),
                                 org.ballerinalang.stdlib.time.util.Constants.CIVIL_RECORD);


### PR DESCRIPTION
In Current approach `Timestamp` and `Timestamp with Timezone` SQL types can only query from `sql:DateTimeValue` datatype.
In this PR it Update `ConvertTimestamp` Methods to use `time:Civil` for Query Operations.

