### PR TITLE
Add Error messages and tests to invalid user records for Datetime Query Operations

### DIFF
--- a/sql-ballerina/tests/complex-query-test.bal
+++ b/sql-ballerina/tests/complex-query-test.bal
@@ -246,17 +246,13 @@ type ResultDates record {
 @test:Config {
     groups: ["query", "query-complex-params"]
 }
-function testDateTime() {
-    MockClient dbClient = checkpanic new (url = complexQueryDb, user = user, password = password);
-    string insertQuery = string `INSERT INTO DateTimeTypes (row_id, date_type, time_type, timestamp_type,
-            datetime_type, time_tz_type, timestamp_tz_type) VALUES (1, '2017-05-23', '14:15:23', '2017-01-25 16:33:55',
-            '2017-01-25 16:33:55', '16:33:55+6:30', '2017-01-25 16:33:55-8:00')`;
-    ExecutionResult? result = checkpanic dbClient->execute(insertQuery);
+function testDateTime() returns error? {
+    MockClient dbClient = check new (url = complexQueryDb, user = user, password = password);
     stream<record{}, error?> queryResult = dbClient->query("SELECT date_type, time_type, timestamp_type, datetime_type"
        + ", time_tz_type, timestamp_tz_type from DateTimeTypes where row_id = 1", ResultDates);
-    record{| record{} value; |}? data =  checkpanic queryResult.next();
+    record{| record{} value; |}? data =  check queryResult.next();
     record{}? value = data?.value;
-    checkpanic dbClient.close();
+    check dbClient.close();
 
     string dateTypeString = "2017-05-23";
     string timeTypeString = "14:15:23";
@@ -276,28 +272,24 @@ function testDateTime() {
 }
 
 type ResultDates2 record {
-    time:Date DATE_TYPE;
-    time:TimeOfDay TIME_TYPE;
-    time:Civil TIMESTAMP_TYPE;
-    time:Civil DATETIME_TYPE;
-    time:TimeOfDay TIME_TZ_TYPE;
-    time:Civil TIMESTAMP_TZ_TYPE;
+    time:Date date_type;
+    time:TimeOfDay time_type;
+    time:Civil timestamp_type;
+    time:Civil datetime_type;
+    time:TimeOfDay time_tz_type;
+    time:Civil timestamp_tz_type;
 };
 
 @test:Config {
     groups: ["query", "query-complex-params"]
 }
-function testDateTime2() {
-    MockClient dbClient = checkpanic new (url = complexQueryDb, user = user, password = password);
-    string insertQuery = string `INSERT INTO DateTimeTypes (row_id, date_type, time_type, timestamp_type,
-            datetime_type, time_tz_type, timestamp_tz_type) VALUES (2, '2017-05-23', '14:15:23', '2017-01-25 16:33:55',
-            '2017-01-25 16:33:55', '16:33:55+6:30', '2017-01-25 16:33:55-8:00')`;
-    ExecutionResult? result = checkpanic dbClient->execute(insertQuery);
+function testDateTime2() returns error? {
+    MockClient dbClient = check new (url = complexQueryDb, user = user, password = password);
     stream<record{}, error?> queryResult = dbClient->query("SELECT date_type, time_type, timestamp_type, datetime_type, "
-            + "time_tz_type, timestamp_tz_type from DateTimeTypes where row_id = 2", ResultDates2);
-    record{| record{} value; |}? data =  checkpanic queryResult.next();
+            + "time_tz_type, timestamp_tz_type from DateTimeTypes where row_id = 1", ResultDates2);
+    record{| record{} value; |}? data =  check queryResult.next();
     record{}? value = data?.value;
-    checkpanic dbClient.close();
+    check dbClient.close();
 
     time:Date dateTypeRecord = {year: 2017, month: 5, day: 23};
     time:TimeOfDay timeTypeRecord = {hour: 14, minute: 15, second:23};
@@ -307,12 +299,12 @@ function testDateTime2() {
                                         month:1, day:25, hour: 16, minute: 33, second:55};
 
     ResultDates2 expected = {
-        DATE_TYPE: dateTypeRecord,
-        TIME_TYPE: timeTypeRecord,
-        TIMESTAMP_TYPE: timestampTypeRecord,
-        DATETIME_TYPE: timestampTypeRecord,
-        TIME_TZ_TYPE: timeWithTimezone,
-        TIMESTAMP_TZ_TYPE: timestampWithTimezone
+        date_type: dateTypeRecord,
+        time_type: timeTypeRecord,
+        timestamp_type: timestampTypeRecord,
+        datetime_type: timestampTypeRecord,
+        time_tz_type: timeWithTimezone,
+        timestamp_tz_type: timestampWithTimezone
     };
     test:assertEquals(value, expected, "Expected record did not match.");
 }
@@ -322,56 +314,52 @@ type RandomType record {|
 |};
 
 type ResultDates3 record {
-    RandomType DATE_TYPE;
-    RandomType TIME_TYPE;
-    RandomType TIMESTAMP_TYPE;
-    RandomType DATETIME_TYPE;
-    RandomType TIME_TZ_TYPE;
-    RandomType TIMESTAMP_TZ_TYPE;
+    RandomType date_type;
+    RandomType time_type;
+    RandomType timestamp_type;
+    RandomType datetime_type;
+    RandomType time_tz_type;
+    RandomType timestamp_tz_type;
 };
 
 @test:Config {
     groups: ["query", "query-complex-params"]
 }
-function testDateTime3() {
+function testDateTime3() returns error? {
     stream<record{}, error?> queryResult;
     record {|record {} value;|} | error? result;
-    MockClient dbClient = checkpanic new (url = complexQueryDb, user = user, password = password);
-    string insertQuery = string `INSERT INTO DateTimeTypes (row_id, date_type, time_type, timestamp_type,
-            datetime_type, time_tz_type, timestamp_tz_type) VALUES (3, '2017-05-23', '14:15:23', '2017-01-25 16:33:55',
-            '2017-01-25 16:33:55', '16:33:55+6:30', '2017-01-25 16:33:55-8:00')`;
-    ExecutionResult? executionResult = checkpanic dbClient->execute(insertQuery);
+    MockClient dbClient = check new (url = complexQueryDb, user = user, password = password);
 
-    queryResult = dbClient->query("SELECT date_type from DateTimeTypes where row_id = 2", ResultDates3);
+    queryResult = dbClient->query("SELECT date_type from DateTimeTypes where row_id = 1", ResultDates3);
     result = queryResult.next();
     test:assertTrue(result is error, "Error Exected for Date type.");
     test:assertTrue(strings:includes((<error>result).message(), "Unsupported Ballerina type"), "Wrong Error Message for Date type.");
 
-    queryResult = dbClient->query("SELECT time_type from DateTimeTypes where row_id = 2", ResultDates3);
+    queryResult = dbClient->query("SELECT time_type from DateTimeTypes where row_id = 1", ResultDates3);
     result = queryResult.next();
     test:assertTrue(result is error, "Error Exected for Time type.");
     test:assertTrue(strings:includes((<error>result).message(), "Unsupported Ballerina type"), "Wrong Error Message for Time type.");
 
-    queryResult = dbClient->query("SELECT timestamp_type from DateTimeTypes where row_id = 2", ResultDates3);
+    queryResult = dbClient->query("SELECT timestamp_type from DateTimeTypes where row_id = 1", ResultDates3);
     result = queryResult.next();
     test:assertTrue(result is error, "Error Exected for Timestamp type.");
     test:assertTrue(strings:includes((<error>result).message(), "Unsupported Ballerina type"), "Wrong Error Message for Timestamp type.");
 
-    queryResult = dbClient->query("SELECT datetime_type from DateTimeTypes where row_id = 2", ResultDates3);
+    queryResult = dbClient->query("SELECT datetime_type from DateTimeTypes where row_id = 1", ResultDates3);
     result = queryResult.next();
     test:assertTrue(result is error, "Error Exected for Datetime type.");
     test:assertTrue(strings:includes((<error>result).message(), "Unsupported Ballerina type"), "Wrong Error Message for Datetime type.");
 
-    queryResult = dbClient->query("SELECT time_tz_type from DateTimeTypes where row_id = 2", ResultDates3);
+    queryResult = dbClient->query("SELECT time_tz_type from DateTimeTypes where row_id = 1", ResultDates3);
     result = queryResult.next();
     test:assertTrue(result is error, "Error Exected for Time with Timezone type.");
     test:assertTrue(strings:includes((<error>result).message(), "Unsupported Ballerina type"), "Wrong Error Message for Time with Timezone type.");
     
-    queryResult = dbClient->query("SELECT timestamp_tz_type from DateTimeTypes where row_id = 2", ResultDates3);
+    queryResult = dbClient->query("SELECT timestamp_tz_type from DateTimeTypes where row_id = 1", ResultDates3);
     result = queryResult.next();
     test:assertTrue(result is error, "Error Exected for Timestamp with Timezone type.");
     test:assertTrue(strings:includes((<error>result).message(), "Unsupported Ballerina type"), "Wrong Error Message for Timestamp with Timezone type.");
-    checkpanic dbClient.close();
+    check dbClient.close();
 }
 
 type ResultSetTestAlias record {

--- a/sql-ballerina/tests/resources/sql/query/complex-test-data.sql
+++ b/sql-ballerina/tests/resources/sql/query/complex-test-data.sql
@@ -113,6 +113,10 @@ CREATE TABLE IF NOT EXISTS DateTimeTypes(
   PRIMARY KEY (row_id)
 );
 
+INSERT INTO DateTimeTypes (row_id, date_type, time_type, timestamp_type,
+            datetime_type, time_tz_type, timestamp_tz_type) VALUES (1, '2017-05-23', '14:15:23', '2017-01-25 16:33:55',
+            '2017-01-25 16:33:55', '16:33:55+6:30', '2017-01-25 16:33:55-8:00');
+
 CREATE TABLE IF NOT EXISTS IntegerTypes (
   id INTEGER,
   intData INTEGER,

--- a/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/DefaultResultParameterProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/DefaultResultParameterProcessor.java
@@ -433,7 +433,7 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
                         }
                     } else {
                         throw new ApplicationError("Unsupported Ballerina type:" +
-                            type.getName() + " for SQL Date Data type.");
+                            type.getName() + " for SQL Date data type.");
                     }
                 case TypeTags.INT_TAG:
                     return date.getTime();
@@ -472,7 +472,7 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
                         }
                     } else {
                         throw new ApplicationError("Unsupported Ballerina type:" +
-                            type.getName() + " for SQL Time Data type.");
+                            type.getName() + " for SQL Time data type.");
                     }
                 case TypeTags.INT_TAG:
                     return time.getTime();
@@ -547,7 +547,7 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
                         return timeMap;
                     } else {
                         throw new ApplicationError("Unsupported Ballerina type:" +
-                            type.getName() + " for SQL Time with timezone Data type.");
+                            type.getName() + " for SQL Time with timezone data type.");
                     }
                 case TypeTags.INT_TAG:
                     return Time.valueOf(offsetTime.toLocalTime()).getTime();
@@ -591,7 +591,7 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
                         return civilMap;
                     } else {
                         throw new ApplicationError("Unsupported Ballerina type:" +
-                            type.getName() + " for SQL Timestamp Data type.");
+                            type.getName() + " for SQL Timestamp data type.");
                     }
                 case TypeTags.INT_TAG:
                     return timestamp.getTime();
@@ -672,7 +672,7 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
                         return civilMap;
                     } else {
                         throw new ApplicationError("Unsupported Ballerina type:" +
-                            type.getName() + " for SQL Timestamp with timezone Data type.");
+                            type.getName() + " for SQL Timestamp with timezone data type.");
                     }
                 case TypeTags.INT_TAG:
                     return Timestamp.valueOf(offsetDateTime.toLocalDateTime()).getTime();

--- a/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/DefaultResultParameterProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/parameterprocessor/DefaultResultParameterProcessor.java
@@ -412,23 +412,28 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
                     return fromString(date.toString());
                 case TypeTags.OBJECT_TYPE_TAG:
                 case TypeTags.RECORD_TYPE_TAG:
-                    if (date instanceof Date) {
-                         LocalDate dateObj = ((Date) date).toLocalDate();
-                        BMap<BString, Object> dateMap = ValueCreator.createRecordValue(
-                                org.ballerinalang.stdlib.time.util.ModuleUtils.getModule(),
-                                org.ballerinalang.stdlib.time.util.Constants.DATE_RECORD);
-                        dateMap.put(StringUtils.fromString(
-                                org.ballerinalang.stdlib.time.util.Constants.DATE_RECORD_YEAR),
-                                dateObj.getYear());
-                        dateMap.put(StringUtils.fromString(
-                                org.ballerinalang.stdlib.time.util.Constants.DATE_RECORD_MONTH),
-                                dateObj.getMonthValue());
-                        dateMap.put(StringUtils.fromString(
-                                org.ballerinalang.stdlib.time.util.Constants.DATE_RECORD_DAY),
-                                dateObj.getDayOfMonth());
-                        return dateMap;
+                    if (type.getName().equals(org.ballerinalang.stdlib.time.util.Constants.DATE_RECORD)) {
+                        if (date instanceof Date) {
+                            LocalDate dateObj = ((Date) date).toLocalDate();
+                            BMap<BString, Object> dateMap = ValueCreator.createRecordValue(
+                                    org.ballerinalang.stdlib.time.util.ModuleUtils.getModule(),
+                                    org.ballerinalang.stdlib.time.util.Constants.DATE_RECORD);
+                            dateMap.put(StringUtils.fromString(
+                                    org.ballerinalang.stdlib.time.util.Constants.DATE_RECORD_YEAR),
+                                    dateObj.getYear());
+                            dateMap.put(StringUtils.fromString(
+                                    org.ballerinalang.stdlib.time.util.Constants.DATE_RECORD_MONTH),
+                                    dateObj.getMonthValue());
+                            dateMap.put(StringUtils.fromString(
+                                    org.ballerinalang.stdlib.time.util.Constants.DATE_RECORD_DAY),
+                                    dateObj.getDayOfMonth());
+                            return dateMap;
+                        } else {
+                            return fromString(date.toString());
+                        }
                     } else {
-                        return fromString(date.toString());
+                        throw new ApplicationError("Unsupported Ballerina type:" +
+                            type.getName() + " for SQL Date Data type.");
                     }
                 case TypeTags.INT_TAG:
                     return date.getTime();
@@ -446,23 +451,28 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
                     return fromString(time.toString());
                 case TypeTags.OBJECT_TYPE_TAG:
                 case TypeTags.RECORD_TYPE_TAG:
-                    if (time instanceof Time) {
-                        LocalTime timeObj = ((Time) time).toLocalTime();
-                        BMap<BString, Object> timeMap = ValueCreator.createRecordValue(
-                                org.ballerinalang.stdlib.time.util.ModuleUtils.getModule(),
-                                org.ballerinalang.stdlib.time.util.Constants.TIME_OF_DAY_RECORD);
-                        timeMap.put(StringUtils.fromString(org.ballerinalang.stdlib.time.util.Constants
-                                .TIME_OF_DAY_RECORD_HOUR), timeObj.getHour());
-                        timeMap.put(StringUtils.fromString(org.ballerinalang.stdlib.time.util.Constants
-                                .TIME_OF_DAY_RECORD_MINUTE) , timeObj.getMinute());
-                        BigDecimal second = new BigDecimal(timeObj.getSecond());
-                        second = second.add(new BigDecimal(timeObj.getNano())
-                                .divide(ANALOG_GIGA, MathContext.DECIMAL128));
-                        timeMap.put(StringUtils.fromString(org.ballerinalang.stdlib.time.util.Constants
-                                .TIME_OF_DAY_RECORD_SECOND), ValueCreator.createDecimalValue(second));
-                        return timeMap;
+                    if (type.getName().equals(org.ballerinalang.stdlib.time.util.Constants.TIME_OF_DAY_RECORD)) {
+                        if (time instanceof Time) {
+                            LocalTime timeObj = ((Time) time).toLocalTime();
+                            BMap<BString, Object> timeMap = ValueCreator.createRecordValue(
+                                    org.ballerinalang.stdlib.time.util.ModuleUtils.getModule(),
+                                    org.ballerinalang.stdlib.time.util.Constants.TIME_OF_DAY_RECORD);
+                            timeMap.put(StringUtils.fromString(org.ballerinalang.stdlib.time.util.Constants
+                                    .TIME_OF_DAY_RECORD_HOUR), timeObj.getHour());
+                            timeMap.put(StringUtils.fromString(org.ballerinalang.stdlib.time.util.Constants
+                                    .TIME_OF_DAY_RECORD_MINUTE) , timeObj.getMinute());
+                            BigDecimal second = new BigDecimal(timeObj.getSecond());
+                            second = second.add(new BigDecimal(timeObj.getNano())
+                                    .divide(ANALOG_GIGA, MathContext.DECIMAL128));
+                            timeMap.put(StringUtils.fromString(org.ballerinalang.stdlib.time.util.Constants
+                                    .TIME_OF_DAY_RECORD_SECOND), ValueCreator.createDecimalValue(second));
+                            return timeMap;
+                        } else {
+                            return fromString(time.toString());
+                        }
                     } else {
-                        return fromString(time.toString());
+                        throw new ApplicationError("Unsupported Ballerina type:" +
+                            type.getName() + " for SQL Time Data type.");
                     }
                 case TypeTags.INT_TAG:
                     return time.getTime();
@@ -481,57 +491,64 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
                     return fromString(offsetTime.toString());
                 case TypeTags.OBJECT_TYPE_TAG:
                 case TypeTags.RECORD_TYPE_TAG:
-                    BMap<BString, Object> timeMap = ValueCreator.createRecordValue(
-                            org.ballerinalang.stdlib.time.util.ModuleUtils.getModule(),
-                            org.ballerinalang.stdlib.time.util.Constants.TIME_OF_DAY_RECORD);
-                    timeMap.put(StringUtils.fromString(org.ballerinalang.stdlib.time.util.Constants
-                            .TIME_OF_DAY_RECORD_HOUR), offsetTime.getHour());
-                    timeMap.put(StringUtils.fromString(org.ballerinalang.stdlib.time.util.Constants
-                            .TIME_OF_DAY_RECORD_MINUTE), offsetTime.getMinute());
-                    BigDecimal second = new BigDecimal(offsetTime.getSecond());
-                    second = second.add(new BigDecimal(offsetTime.getNano()).divide(ANALOG_GIGA,
-                            MathContext.DECIMAL128));
-                    timeMap.put(StringUtils.fromString(org.ballerinalang.stdlib.time.util.Constants
-                            .TIME_OF_DAY_RECORD_SECOND), ValueCreator.createDecimalValue(second));
-                    Map<String, Integer> zoneInfo = TimeValueHandler
-                            .zoneOffsetMapFromString(offsetTime.getOffset().toString());
-                    BMap<BString, Object> zoneMap = ValueCreator.createRecordValue(ModuleUtils.getModule(),
-                            org.ballerinalang.stdlib.time.util.Constants.READABLE_ZONE_OFFSET_RECORD);
-
-                    if (zoneInfo.get(org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_HOUR) != null) {
-                        zoneMap.put(StringUtils.fromString(
-                                org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_HOUR),
-                                zoneInfo.get(org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_HOUR)
+                    if (type.getName().equals(org.ballerinalang.stdlib.time.util.Constants.TIME_OF_DAY_RECORD)) {
+                        BMap<BString, Object> timeMap = ValueCreator.createRecordValue(
+                                org.ballerinalang.stdlib.time.util.ModuleUtils.getModule(),
+                                org.ballerinalang.stdlib.time.util.Constants.TIME_OF_DAY_RECORD);
+                        timeMap.put(StringUtils.fromString(org.ballerinalang.stdlib.time.util.Constants
+                                .TIME_OF_DAY_RECORD_HOUR), offsetTime.getHour());
+                        timeMap.put(StringUtils.fromString(org.ballerinalang.stdlib.time.util.Constants
+                                .TIME_OF_DAY_RECORD_MINUTE), offsetTime.getMinute());
+                        BigDecimal second = new BigDecimal(offsetTime.getSecond());
+                        second = second.add(new BigDecimal(offsetTime.getNano()).divide(ANALOG_GIGA,
+                                MathContext.DECIMAL128));
+                        timeMap.put(StringUtils.fromString(org.ballerinalang.stdlib.time.util.Constants
+                                .TIME_OF_DAY_RECORD_SECOND), ValueCreator.createDecimalValue(second));
+                        Map<String, Integer> zoneInfo = TimeValueHandler
+                                .zoneOffsetMapFromString(offsetTime.getOffset().toString());
+                        BMap<BString, Object> zoneMap = ValueCreator.createRecordValue(
+                                org.ballerinalang.stdlib.time.util.ModuleUtils.getModule(),
+                                org.ballerinalang.stdlib.time.util.Constants.READABLE_ZONE_OFFSET_RECORD);
+                        if (zoneInfo
+                            .get(org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_HOUR) != null) {
+                            zoneMap.put(StringUtils.fromString(
+                                    org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_HOUR),
+                                    zoneInfo.get(org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_HOUR)
+                                            .longValue());
+                        } else {
+                            zoneMap.put(StringUtils.fromString(
+                                    org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_HOUR), 0);
+                        }
+                        if (zoneInfo
+                            .get(org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_MINUTE) != null) {
+                            zoneMap.put(StringUtils.fromString(
+                                    org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_MINUTE),
+                                    zoneInfo
+                                        .get(org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_MINUTE)
                                         .longValue());
+                        } else {
+                            zoneMap.put(StringUtils.fromString(
+                                    org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_MINUTE), 0);
+                        }
+                        if (zoneInfo
+                            .get(org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_SECOND) != null) {
+                            zoneMap.put(StringUtils.fromString(
+                                    org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_SECOND),
+                                    zoneInfo
+                                    .get(org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_SECOND)
+                                    .longValue());
+                        }
+                        zoneMap.freezeDirect();
+                        timeMap.put(StringUtils.fromString(
+                                org.ballerinalang.stdlib.time.util.Constants.CIVIL_RECORD_UTC_OFFSET), zoneMap);
+                        timeMap.put(StringUtils.fromString(
+                                org.ballerinalang.stdlib.time.util.Constants.CIVIL_RECORD_TIME_ABBREV),
+                                StringUtils.fromString(offsetTime.getOffset().toString()));
+                        return timeMap;
                     } else {
-                        zoneMap.put(StringUtils.fromString(
-                                org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_HOUR), 0);
+                        throw new ApplicationError("Unsupported Ballerina type:" +
+                            type.getName() + " for SQL Time with timezone Data type.");
                     }
-
-                    if (zoneInfo.get(org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_MINUTE) != null) {
-                        zoneMap.put(StringUtils.fromString(
-                                org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_MINUTE),
-                                zoneInfo.get(org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_MINUTE)
-                                        .longValue());
-                    } else {
-                        zoneMap.put(StringUtils.fromString(
-                                org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_MINUTE), 0);
-                    }
-
-                    if (zoneInfo.get(org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_SECOND) != null) {
-                        zoneMap.put(StringUtils.fromString(
-                                org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_SECOND),
-                                zoneInfo.get(org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_SECOND)
-                                .longValue());
-                    }
-
-                    zoneMap.freezeDirect();
-                    timeMap.put(StringUtils.fromString(
-                            org.ballerinalang.stdlib.time.util.Constants.CIVIL_RECORD_UTC_OFFSET), zoneMap);
-                    timeMap.put(StringUtils.fromString(
-                            org.ballerinalang.stdlib.time.util.Constants.CIVIL_RECORD_TIME_ABBREV),
-                            offsetTime.getOffset().toString());
-                    return timeMap;
                 case TypeTags.INT_TAG:
                     return Time.valueOf(offsetTime.toLocalTime()).getTime();
             }
@@ -573,7 +590,8 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
                                 .TIME_OF_DAY_RECORD_SECOND), ValueCreator.createDecimalValue(second));
                         return civilMap;
                     } else {
-                        return Utils.createTimeStruct(timestamp.getTime());
+                        throw new ApplicationError("Unsupported Ballerina type:" +
+                            type.getName() + " for SQL Timestamp Data type.");
                     }
                 case TypeTags.INT_TAG:
                     return timestamp.getTime();
@@ -615,9 +633,9 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
                                 .TIME_OF_DAY_RECORD_SECOND), ValueCreator.createDecimalValue(second));
                         Map<String, Integer> zoneInfo = TimeValueHandler
                                 .zoneOffsetMapFromString(offsetDateTime.getOffset().toString());
-                        BMap<BString, Object> zoneMap = ValueCreator.createRecordValue(ModuleUtils.getModule(),
+                        BMap<BString, Object> zoneMap = ValueCreator.createRecordValue(
+                                org.ballerinalang.stdlib.time.util.ModuleUtils.getModule(),
                                 org.ballerinalang.stdlib.time.util.Constants.READABLE_ZONE_OFFSET_RECORD);
-
                         if (zoneInfo.get(org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_HOUR)
                                 != null) {
                             zoneMap.put(StringUtils.fromString(
@@ -628,7 +646,6 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
                             zoneMap.put(StringUtils.fromString(
                                     org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_HOUR), 0);
                         }
-
                         if (zoneInfo.get(org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_MINUTE)
                                 != null) {
                             zoneMap.put(StringUtils.fromString(
@@ -639,7 +656,6 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
                             zoneMap.put(StringUtils.fromString(
                                     org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_MINUTE), 0);
                         }
-
                         if (zoneInfo.get(org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_SECOND)
                                 != null) {
                             zoneMap.put(StringUtils.fromString(
@@ -647,16 +663,16 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
                                     zoneInfo.get(org.ballerinalang.stdlib.time.util.Constants.ZONE_OFFSET_RECORD_SECOND)
                                             .longValue());
                         }
-
                         zoneMap.freezeDirect();
                         civilMap.put(StringUtils.fromString(
                                 org.ballerinalang.stdlib.time.util.Constants.CIVIL_RECORD_UTC_OFFSET), zoneMap);
                         civilMap.put(StringUtils.fromString(
                                 org.ballerinalang.stdlib.time.util.Constants.CIVIL_RECORD_TIME_ABBREV),
-                                offsetDateTime.getOffset().toString());
+                                StringUtils.fromString(offsetDateTime.getOffset().toString()));
                         return civilMap;
                     } else {
-                        return Utils.createTimeStruct(Timestamp.valueOf(offsetDateTime.toLocalDateTime()).getTime());
+                        throw new ApplicationError("Unsupported Ballerina type:" +
+                            type.getName() + " for SQL Timestamp with timezone Data type.");
                     }
                 case TypeTags.INT_TAG:
                     return Timestamp.valueOf(offsetDateTime.toLocalDateTime()).getTime();


### PR DESCRIPTION
>Update `Convert` functions of Datetime types to give errors if User provides a invalid record in Query Operation

Resolves https://github.com/ballerina-platform/ballerina-standard-library/issues/679