### PR TITLE
Move clientActive flag to java level and remove deprecated usage

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,10 +4,10 @@ This file contains all the notable changes done to the Ballerina SQL package thr
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
 
 ## [0.6.0-beta.1] - 2021-05-11
 
 ### Added
-
 - [Introduced `ArrayValueType` type and `TypedValue` object to configure the types of an SQL array](https://github.com/ballerina-platform/ballerina-standard-library/issues/104)
 - Newly introduce TimeWithTimezoneOutParameter and TimestampWithTimezoneOutParameter for using TimeWithTimeZone Type OutParameter

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Add DB connection active status check in native code level
+
 ## [0.6.0-beta.1] - 2021-05-11
 
 ### Added

--- a/sql-native/src/main/java/org/ballerinalang/sql/datasource/SQLDatasource.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/datasource/SQLDatasource.java
@@ -56,6 +56,7 @@ public class SQLDatasource {
     private Lock mutex = new ReentrantLock();
     private boolean poolShutdown = false;
     private boolean xaConn;
+    private boolean clientActive = true;
     private AtomikosDataSourceBean atomikosDataSourceBean;
     private HikariDataSource hikariDataSource;
     private XADataSource xaDataSource;
@@ -84,7 +85,6 @@ public class SQLDatasource {
                 return;
             }
             connection = getConnection();
-
         } catch (SQLException e) {
             throw ErrorGenerator.getSQLDatabaseError(e,
                     "error while verifying the connection for " + Constants.CONNECTOR_NAME + ", ");
@@ -237,6 +237,10 @@ public class SQLDatasource {
         return newSqlDatasource;
     }
 
+    public boolean isClosed() {
+        return !clientActive;
+    }
+
     private Connection getConnection() throws SQLException {
       if (atomikosDataSourceBean != null) {
           return atomikosDataSourceBean.getConnection();
@@ -258,10 +262,12 @@ public class SQLDatasource {
     private void closeConnectionPool() {
         if (hikariDataSource != null) {
             hikariDataSource.close();
+            clientActive = false;
         }
 
         if (atomikosDataSourceBean != null) {
             atomikosDataSourceBean.close();
+            clientActive = false;
         }
         poolShutdown = true;
     }

--- a/sql-native/src/main/java/org/ballerinalang/sql/datasource/SQLDatasource.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/datasource/SQLDatasource.java
@@ -56,7 +56,6 @@ public class SQLDatasource {
     private Lock mutex = new ReentrantLock();
     private boolean poolShutdown = false;
     private boolean xaConn;
-    private boolean clientActive = true;
     private AtomikosDataSourceBean atomikosDataSourceBean;
     private HikariDataSource hikariDataSource;
     private XADataSource xaDataSource;
@@ -237,10 +236,6 @@ public class SQLDatasource {
         return newSqlDatasource;
     }
 
-    public boolean isClosed() {
-        return !clientActive;
-    }
-
     private Connection getConnection() throws SQLException {
       if (atomikosDataSourceBean != null) {
           return atomikosDataSourceBean.getConnection();
@@ -262,17 +257,15 @@ public class SQLDatasource {
     private void closeConnectionPool() {
         if (hikariDataSource != null) {
             hikariDataSource.close();
-            clientActive = false;
         }
 
         if (atomikosDataSourceBean != null) {
             atomikosDataSourceBean.close();
-            clientActive = false;
         }
         poolShutdown = true;
     }
 
-    private boolean isPoolShutdown() {
+    public boolean isPoolShutdown() {
         return poolShutdown;
     }
 

--- a/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/CallProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/CallProcessor.java
@@ -87,7 +87,7 @@ public class CallProcessor {
         TransactionResourceManager trxResourceManager = TransactionResourceManager.getInstance();
         if (dbClient != null) {
             SQLDatasource sqlDatasource = (SQLDatasource) dbClient;
-            if (sqlDatasource.isClosed()) {
+            if (sqlDatasource.isPoolShutdown()) {
                 return ErrorGenerator.getSQLApplicationError("SQL Client is already closed, hence further operations" +
                         " are not allowed");
             }

--- a/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/CallProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/CallProcessor.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.sql.nativeimpl;
 
+import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
@@ -86,6 +87,10 @@ public class CallProcessor {
         TransactionResourceManager trxResourceManager = TransactionResourceManager.getInstance();
         if (dbClient != null) {
             SQLDatasource sqlDatasource = (SQLDatasource) dbClient;
+            if (sqlDatasource.isClosed()) {
+                return ErrorGenerator.getSQLApplicationError("SQL Client is already closed, hence further operations" +
+                        " are not allowed");
+            }
             Connection connection;
             CallableStatement statement;
             ResultSet resultSet;
@@ -130,7 +135,8 @@ public class CallProcessor {
                         columnDefinitions = getColumnDefinitions(resultSet, streamConstraint);
                         resultSetCount++;
                     }
-                    BStream streamValue = ValueCreator.createStreamValue(TypeCreator.createStreamType(streamConstraint),
+                    BStream streamValue = ValueCreator.createStreamValue(TypeCreator.createStreamType(streamConstraint,
+                            PredefinedTypes.TYPE_NULL),
                         resultParameterProcessor.createRecordIterator(resultSet, null, null, columnDefinitions,
                                                      streamConstraint));
                     procedureCallResult.set(QUERY_RESULT_FIELD, streamValue);

--- a/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/ExecuteProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/ExecuteProcessor.java
@@ -73,6 +73,10 @@ public class ExecuteProcessor {
         TransactionResourceManager trxResourceManager = TransactionResourceManager.getInstance();
         if (dbClient != null) {
             SQLDatasource sqlDatasource = (SQLDatasource) dbClient;
+            if (sqlDatasource.isClosed()) {
+                return ErrorGenerator.getSQLApplicationError("SQL Client is already closed, hence further operations" +
+                        " are not allowed");
+            }
             Connection connection = null;
             PreparedStatement statement = null;
             ResultSet resultSet = null;
@@ -128,6 +132,10 @@ public class ExecuteProcessor {
         Object dbClient = client.getNativeData(Constants.DATABASE_CLIENT);
         if (dbClient != null) {
             SQLDatasource sqlDatasource = (SQLDatasource) dbClient;
+            if (sqlDatasource.isClosed()) {
+                return ErrorGenerator.getSQLApplicationError("SQL Client is already closed, hence further operations" +
+                        " are not allowed");
+            }
             Connection connection = null;
             PreparedStatement statement = null;
             ResultSet resultSet = null;

--- a/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/ExecuteProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/ExecuteProcessor.java
@@ -73,7 +73,7 @@ public class ExecuteProcessor {
         TransactionResourceManager trxResourceManager = TransactionResourceManager.getInstance();
         if (dbClient != null) {
             SQLDatasource sqlDatasource = (SQLDatasource) dbClient;
-            if (sqlDatasource.isClosed()) {
+            if (sqlDatasource.isPoolShutdown()) {
                 return ErrorGenerator.getSQLApplicationError("SQL Client is already closed, hence further operations" +
                         " are not allowed");
             }
@@ -132,7 +132,7 @@ public class ExecuteProcessor {
         Object dbClient = client.getNativeData(Constants.DATABASE_CLIENT);
         if (dbClient != null) {
             SQLDatasource sqlDatasource = (SQLDatasource) dbClient;
-            if (sqlDatasource.isClosed()) {
+            if (sqlDatasource.isPoolShutdown()) {
                 return ErrorGenerator.getSQLApplicationError("SQL Client is already closed, hence further operations" +
                         " are not allowed");
             }

--- a/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/QueryProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/QueryProcessor.java
@@ -73,7 +73,7 @@ public class QueryProcessor {
         TransactionResourceManager trxResourceManager = TransactionResourceManager.getInstance();
         if (dbClient != null) {
             SQLDatasource sqlDatasource = (SQLDatasource) dbClient;
-            if (sqlDatasource.isClosed()) {
+            if (sqlDatasource.isPoolShutdown()) {
                 BError errorValue = ErrorGenerator.getSQLApplicationError("SQL Client is already closed, hence " +
                         "further operations are not allowed");
                 return getErrorStream(recordType, errorValue);

--- a/sql-native/src/main/java/org/ballerinalang/sql/utils/ProcedureCallResultUtils.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/utils/ProcedureCallResultUtils.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.sql.utils;
 
+import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.StructureType;
@@ -87,7 +88,7 @@ public class ProcedureCallResultUtils {
                     }
                 }
                 BStream streamValue = ValueCreator.createStreamValue(
-                        TypeCreator.createStreamType(streamConstraint),
+                        TypeCreator.createStreamType(streamConstraint, PredefinedTypes.TYPE_NULL),
                         resultParameterProcessor.createRecordIterator(resultSet, null, null,
                                 columnDefinitions, streamConstraint));
                 procedureCallResult.set(QUERY_RESULT_FIELD, streamValue);


### PR DESCRIPTION
## Purpose
$Title to support db connectors to make their classes isolated.

Fixes:

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests