### PR TITLE
Remove statement.getGeneratedKeys() usage in call execution result

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Add DB connection active status check in native code level
+- [Remove sending `lastInsertId` in `ExecutionResult` for remote call function](https://github.com/ballerina-platform/ballerina-standard-library/issues/1409)
 
 ## [0.6.0-beta.1] - 2021-05-11
 

--- a/sql-native/src/main/java/org/ballerinalang/sql/utils/Utils.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/utils/Utils.java
@@ -72,7 +72,6 @@ import static io.ballerina.runtime.api.utils.StringUtils.fromString;
 import static org.ballerinalang.sql.Constants.AFFECTED_ROW_COUNT_FIELD;
 import static org.ballerinalang.sql.Constants.EXECUTION_RESULT_FIELD;
 import static org.ballerinalang.sql.Constants.EXECUTION_RESULT_RECORD;
-import static org.ballerinalang.sql.Constants.LAST_INSERTED_ID_FIELD;
 import static org.ballerinalang.stdlib.time.util.Constants.ANALOG_GIGA;
 
 /**
@@ -233,15 +232,9 @@ public class Utils {
 
     public static void updateProcedureCallExecutionResult(CallableStatement statement, BObject procedureCallResult)
             throws SQLException {
-        Object lastInsertedId = null;
         int count = statement.getUpdateCount();
-        ResultSet resultSet = statement.getGeneratedKeys();
-        if (resultSet.next()) {
-            lastInsertedId = getGeneratedKeys(resultSet);
-        }
         Map<String, Object> resultFields = new HashMap<>();
         resultFields.put(AFFECTED_ROW_COUNT_FIELD, count);
-        resultFields.put(LAST_INSERTED_ID_FIELD, lastInsertedId);
         BMap<BString, Object> executionResult = ValueCreator.createRecordValue(
                 ModuleUtils.getModule(), EXECUTION_RESULT_RECORD, resultFields);
         procedureCallResult.set(EXECUTION_RESULT_FIELD, executionResult);

--- a/sql-native/src/main/java/org/ballerinalang/sql/utils/Utils.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/utils/Utils.java
@@ -72,6 +72,7 @@ import static io.ballerina.runtime.api.utils.StringUtils.fromString;
 import static org.ballerinalang.sql.Constants.AFFECTED_ROW_COUNT_FIELD;
 import static org.ballerinalang.sql.Constants.EXECUTION_RESULT_FIELD;
 import static org.ballerinalang.sql.Constants.EXECUTION_RESULT_RECORD;
+import static org.ballerinalang.sql.Constants.LAST_INSERTED_ID_FIELD;
 import static org.ballerinalang.stdlib.time.util.Constants.ANALOG_GIGA;
 
 /**
@@ -232,9 +233,11 @@ public class Utils {
 
     public static void updateProcedureCallExecutionResult(CallableStatement statement, BObject procedureCallResult)
             throws SQLException {
+        Object lastInsertedId = null;
         int count = statement.getUpdateCount();
         Map<String, Object> resultFields = new HashMap<>();
         resultFields.put(AFFECTED_ROW_COUNT_FIELD, count);
+        resultFields.put(LAST_INSERTED_ID_FIELD, lastInsertedId);
         BMap<BString, Object> executionResult = ValueCreator.createRecordValue(
                 ModuleUtils.getModule(), EXECUTION_RESULT_RECORD, resultFields);
         procedureCallResult.set(EXECUTION_RESULT_FIELD, executionResult);


### PR DESCRIPTION
## Purpose
$title

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1409

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests