### PR TITLE
Change returning stream type of the query remote method

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- [Change default rowType of the query remote method from `nil` to `<>`](https://github.com/ballerina-platform/ballerina-standard-library/issues/1445)
+
+## [0.6.0-beta.1] - 2021-06-02
+
+### Changed
 - Add DB connection active status check in native code level
 - [Remove sending `lastInsertId` in `ExecutionResult` for remote call function](https://github.com/ballerina-platform/ballerina-standard-library/issues/1409)
-
-## [0.6.0-beta.1] - 2021-05-11
 
 ### Added
 - [Introduced `ArrayValueType` type and `TypedValue` object to configure the types of an SQL array](https://github.com/ballerina-platform/ballerina-standard-library/issues/104)

--- a/sql-ballerina/client.bal
+++ b/sql-ballerina/client.bal
@@ -27,8 +27,8 @@ public type Client client object {
     # + rowType - The `typedesc` of the record that should be returned as a result. If this is not provided, the default
     #             column names of the query result set will be used for the record attributes
     # + return - Stream of records in the type of `rowType`
-    remote isolated function query(@untainted string|ParameterizedQuery sqlQuery, typedesc<record {}>? rowType = ())
-    returns @tainted stream <record {}, Error>;
+    remote isolated function query(@untainted string|ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>)
+    returns @tainted stream <rowType, Error>;
 
     # Executes the provided DDL or DML SQL query and returns a summary of the execution.
     #

--- a/sql-ballerina/tests/client.bal
+++ b/sql-ballerina/tests/client.bal
@@ -60,9 +60,10 @@ isolated client class MockClient {
         name: "nativeCall"
     } external;
 
-    public isolated function close() returns Error? {
-        return close(self);
-    }
+    public isolated function close() returns Error? = @java:Method {
+         'class: "org.ballerinalang.sql.testutils.ClientTestUtils",
+         name: "close"
+    } external;
 }
 
 type SQLParams record {|
@@ -83,8 +84,4 @@ returns Error? = @java:Method {
 isolated function nativeBatchExecute(Client sqlClient, ParameterizedQuery[] sqlQueries)
 returns ExecutionResult[]|Error = @java:Method {
     'class: "org.ballerinalang.sql.testutils.ExecuteTestUtils"
-} external;
-
-isolated function close(Client Client) returns Error? = @java:Method {
-    'class: "org.ballerinalang.sql.testutils.ClientTestUtils"
 } external;

--- a/sql-ballerina/tests/client.bal
+++ b/sql-ballerina/tests/client.bal
@@ -35,14 +35,17 @@ isolated client class MockClient {
         return createSqlClient(self, sqlParams, getGlobalConnectionPool());
     }
 
-    remote isolated function query(@untainted string|ParameterizedQuery sqlQuery, typedesc<record {}>? rowType = ())
-    returns @tainted stream <record {}, Error> {
-        return nativeQuery(self, sqlQuery, rowType);
-    }
+    remote isolated function query(@untainted string|ParameterizedQuery sqlQuery, typedesc<record {}> rowType = <>)
+    returns @tainted stream <rowType, Error> = @java:Method {
+        'class: "org.ballerinalang.sql.testutils.QueryTestUtils",
+        name: "nativeQuery"
+    } external;
 
-    remote isolated function execute(@untainted string|ParameterizedQuery sqlQuery) returns ExecutionResult|Error {
-        return nativeExecute(self, sqlQuery);
-    }
+    remote isolated function execute(@untainted string|ParameterizedQuery sqlQuery)
+    returns ExecutionResult|Error = @java:Method {
+        'class: "org.ballerinalang.sql.testutils.ExecuteTestUtils",
+        name: "nativeExecute"
+    } external;
 
     remote isolated function batchExecute(@untainted ParameterizedQuery[] sqlQueries) returns ExecutionResult[]|Error {
         if (sqlQueries.length() == 0) {
@@ -52,9 +55,10 @@ isolated client class MockClient {
     }
 
     remote isolated function call(@untainted string|ParameterizedCallQuery sqlQuery, typedesc<record {}>[] rowTypes = [])
-    returns ProcedureCallResult|Error {
-        return nativeCall(self, sqlQuery, rowTypes);
-    }
+    returns ProcedureCallResult|Error = @java:Method {
+        'class: "org.ballerinalang.sql.testutils.CallTestUtils",
+        name: "nativeCall"
+    } external;
 
     public isolated function close() returns Error? {
         return close(self);
@@ -76,24 +80,9 @@ returns Error? = @java:Method {
     'class: "org.ballerinalang.sql.testutils.ClientTestUtils"
 } external;
 
-isolated function nativeQuery(Client sqlClient, string|ParameterizedQuery sqlQuery, typedesc<record {}>? rowType)
-returns stream <record {}, Error> = @java:Method {
-    'class: "org.ballerinalang.sql.testutils.QueryTestUtils"
-} external;
-
-isolated function nativeExecute(Client sqlClient, string|ParameterizedQuery sqlQuery)
-returns ExecutionResult|Error = @java:Method {
-    'class: "org.ballerinalang.sql.testutils.ExecuteTestUtils"
-} external;
-
 isolated function nativeBatchExecute(Client sqlClient, ParameterizedQuery[] sqlQueries)
 returns ExecutionResult[]|Error = @java:Method {
     'class: "org.ballerinalang.sql.testutils.ExecuteTestUtils"
-} external;
-
-isolated function nativeCall(Client sqlClient, string|ParameterizedCallQuery sqlQuery, typedesc<record {}>[] rowTypes)
-returns ProcedureCallResult|Error = @java:Method {
-    'class: "org.ballerinalang.sql.testutils.CallTestUtils"
 } external;
 
 isolated function close(Client Client) returns Error? = @java:Method {

--- a/sql-ballerina/tests/complex-query-test.bal
+++ b/sql-ballerina/tests/complex-query-test.bal
@@ -67,6 +67,60 @@ function testGetPrimitiveTypes() returns error? {
 @test:Config {
     groups: ["query", "query-complex-params"]
 }
+function testGetPrimitiveTypes2() returns error? {
+    MockClient dbClient = check new (url = complexQueryDb, user = user, password = password);
+    stream<SelectTestAlias, error?> streamData = dbClient->query(
+	"SELECT int_type, long_type, double_type,"
+        + "boolean_type, string_type from DataTable WHERE row_id = 1", SelectTestAlias);
+    record {|SelectTestAlias value;|}? data = check streamData.next();
+    check streamData.close();
+    SelectTestAlias? value = data?.value;
+    check dbClient.close();
+
+    SelectTestAlias expectedData = {
+        int_type: 1,
+        long_type: 9223372036854774807,
+        double_type: 2139095039,
+        boolean_type: true,
+        string_type: "Hello"
+    };
+    test:assertEquals(value, expectedData, "Expected data did not match.");
+    test:assertTrue(value is SelectTestAlias, "Received value type is different.");
+}
+
+type SelectTestAlias2 record {
+    int int_type;
+    int long_type;
+    float double_type;
+};
+
+@test:Config {
+    groups: ["query", "query-complex-params"]
+}
+function testGetPrimitiveTypesLessFields() returns error? {
+    MockClient dbClient = check new (url = complexQueryDb, user = user, password = password);
+    stream<SelectTestAlias2, error?> streamData = dbClient->query(
+	"SELECT int_type, long_type, double_type,"
+        + "boolean_type, string_type from DataTable WHERE row_id = 1", SelectTestAlias2);
+    record {|SelectTestAlias2 value;|}? data = check streamData.next();
+    check streamData.close();
+    SelectTestAlias2? value = data?.value;
+    check dbClient.close();
+
+    var expectedData = {
+        int_type: 1,
+        long_type: 9223372036854774807,
+        double_type: 2.139095039E9,
+        BOOLEAN_TYPE: true,
+        STRING_TYPE: "Hello"
+    };
+    test:assertEquals(value, expectedData, "Expected data did not match.");
+    test:assertTrue(value is SelectTestAlias2, "Received value type is different.");
+}
+
+@test:Config {
+    groups: ["query", "query-complex-params"]
+}
 function testToJson() returns error? {
     MockClient dbClient = check new (url = complexQueryDb, user = user, password = password);
     stream<record{}, error?> streamData = dbClient->query(
@@ -110,6 +164,7 @@ function testToJsonComplexTypes() returns error? {
         BINARY_TYPE: "wso2 ballerina binary test.".toBytes()
     };
     test:assertEquals(value, complexStringType, "Expected record did not match.");
+    test:assertTrue(data is record {|record{} value;|}, "Received value type is different.");
 }
 
 @test:Config {

--- a/sql-ballerina/tests/complex-query-test.bal
+++ b/sql-ballerina/tests/complex-query-test.bal
@@ -88,6 +88,30 @@ function testGetPrimitiveTypes2() returns error? {
     test:assertTrue(value is SelectTestAlias, "Received value type is different.");
 }
 
+@test:Config {
+    groups: ["query", "query-complex-params"]
+}
+function testGetPrimitiveTypes3() returns error? {
+    MockClient dbClient = check new (url = complexQueryDb, user = user, password = password);
+    stream<SelectTestAlias, error?> streamData = dbClient->query(
+	"SELECT int_type, long_type, double_type,"
+        + "boolean_type, string_type from DataTable WHERE row_id = 1");
+    record {|SelectTestAlias value;|}? data = check streamData.next();
+    check streamData.close();
+    SelectTestAlias? value = data?.value;
+    check dbClient.close();
+
+    SelectTestAlias expectedData = {
+        int_type: 1,
+        long_type: 9223372036854774807,
+        double_type: 2139095039,
+        boolean_type: true,
+        string_type: "Hello"
+    };
+    test:assertEquals(value, expectedData, "Expected data did not match.");
+    test:assertTrue(value is SelectTestAlias, "Received value type is different.");
+}
+
 type SelectTestAlias2 record {
     int int_type;
     int long_type;

--- a/sql-ballerina/tests/complex-query-test.bal
+++ b/sql-ballerina/tests/complex-query-test.bal
@@ -44,7 +44,6 @@ type SelectTestAlias record {
 @test:Config {
     groups: ["query", "query-complex-params"]
 }
-
 function testGetPrimitiveTypes() returns error? {
     MockClient dbClient = check new (url = complexQueryDb, user = user, password = password);
     stream<record{}, error?> streamData = dbClient->query(

--- a/sql-ballerina/tests/numerical-query-test.bal
+++ b/sql-ballerina/tests/numerical-query-test.bal
@@ -98,7 +98,7 @@ function testQueryNumericTypeRecord() returns error? {
     test:assertTrue(returnData?.float_type is float);
 }
 
-type NumericInvalidColumn record {
+type NumericInvalidColumn record {|
     int num_id;
     int int_type;
     int bigint_type;
@@ -109,7 +109,7 @@ type NumericInvalidColumn record {
     decimal numeric_type;
     float float_type;
     float real_type;
-};
+|};
 
 @test:Config {
     groups: ["query", "query-numeric-params"]

--- a/sql-native/src/main/java/org/ballerinalang/sql/Constants.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/Constants.java
@@ -62,6 +62,7 @@ public final class Constants {
     public static final String EXECUTION_RESULT_RECORD = "ExecutionResult";
     public static final String AFFECTED_ROW_COUNT_FIELD = "affectedRowCount";
     public static final String LAST_INSERTED_ID_FIELD = "lastInsertId";
+    public static final String DEFAULT_RECORD_NAME = "record {| anydata...; |}";
 
     public static final String READ_BYTE_CHANNEL_STRUCT = "ReadableByteChannel";
     public static final String READ_CHAR_CHANNEL_STRUCT = "ReadableCharacterChannel";

--- a/sql-native/src/main/java/org/ballerinalang/sql/Constants.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/Constants.java
@@ -62,7 +62,6 @@ public final class Constants {
     public static final String EXECUTION_RESULT_RECORD = "ExecutionResult";
     public static final String AFFECTED_ROW_COUNT_FIELD = "affectedRowCount";
     public static final String LAST_INSERTED_ID_FIELD = "lastInsertId";
-    public static final String DEFAULT_RECORD_NAME = "record {| anydata...; |}";
 
     public static final String READ_BYTE_CHANNEL_STRUCT = "ReadableByteChannel";
     public static final String READ_CHAR_CHANNEL_STRUCT = "ReadableCharacterChannel";

--- a/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/QueryProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/QueryProcessor.java
@@ -93,10 +93,8 @@ public class QueryProcessor {
                     statementParameterProcessor.setParams(connection, statement, (BObject) paramSQLString);
                 }
                 resultSet = statement.executeQuery();
-                List<ColumnDefinition> columnDefinitions;
-                RecordType streamConstraint;
-                streamConstraint = (RecordType) ((BTypedesc) recordType).getDescribingType();
-                columnDefinitions = Utils.getColumnDefinitions(resultSet, streamConstraint);
+                RecordType streamConstraint = (RecordType) ((BTypedesc) recordType).getDescribingType();
+                List<ColumnDefinition> columnDefinitions = Utils.getColumnDefinitions(resultSet, streamConstraint);
                 return ValueCreator.createStreamValue(TypeCreator.createStreamType(streamConstraint,
                         PredefinedTypes.TYPE_NULL), resultParameterProcessor
                         .createRecordIterator(resultSet, statement, connection, columnDefinitions, streamConstraint));

--- a/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/QueryProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/QueryProcessor.java
@@ -95,9 +95,7 @@ public class QueryProcessor {
                 resultSet = statement.executeQuery();
                 List<ColumnDefinition> columnDefinitions;
                 StructureType streamConstraint;
-                if (((BTypedesc) recordType).getDescribingType()
-                        .equals(TypeCreator.createRecordType(Constants.DEFAULT_RECORD_NAME, ModuleUtils.getModule(),
-                        2049, false, 6))) {
+                if (((BTypedesc) recordType).getDescribingType().getName().equals(Constants.DEFAULT_RECORD_NAME)) {
                     columnDefinitions = Utils.getColumnDefinitions(resultSet, null);
                     streamConstraint = Utils.getDefaultRecordType(columnDefinitions);
                 } else {

--- a/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/QueryProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/QueryProcessor.java
@@ -95,7 +95,9 @@ public class QueryProcessor {
                 resultSet = statement.executeQuery();
                 List<ColumnDefinition> columnDefinitions;
                 StructureType streamConstraint;
-                if (((BTypedesc) recordType).getDescribingType().getName().equals(Constants.DEFAULT_RECORD_NAME)) {
+                if (((BTypedesc) recordType).getDescribingType()
+                        .equals(TypeCreator.createRecordType(Constants.DEFAULT_RECORD_NAME, ModuleUtils.getModule(),
+                        2049, false, 6))) {
                     columnDefinitions = Utils.getColumnDefinitions(resultSet, null);
                     streamConstraint = Utils.getDefaultRecordType(columnDefinitions);
                 } else {

--- a/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/QueryProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/QueryProcessor.java
@@ -18,7 +18,6 @@
 
 package org.ballerinalang.sql.nativeimpl;
 
-
 import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
@@ -96,7 +95,7 @@ public class QueryProcessor {
                 resultSet = statement.executeQuery();
                 List<ColumnDefinition> columnDefinitions;
                 StructureType streamConstraint;
-                if (recordType == null) {
+                if (((BTypedesc) recordType).getDescribingType().getName().equals(Constants.DEFAULT_RECORD_NAME)) {
                     columnDefinitions = Utils.getColumnDefinitions(resultSet, null);
                     streamConstraint = Utils.getDefaultRecordType(columnDefinitions);
                 } else {
@@ -133,15 +132,9 @@ public class QueryProcessor {
     }
 
     private static BStream getErrorStream(Object recordType, BError errorValue) {
-        if (recordType == null) {
-            return ValueCreator.createStreamValue(
-                    TypeCreator.createStreamType(Utils.getDefaultStreamConstraint(), PredefinedTypes.TYPE_NULL),
-                    createRecordIterator(errorValue));
-        } else {
-            return ValueCreator.createStreamValue(
-                    TypeCreator.createStreamType(((BTypedesc) recordType).getDescribingType(),
-                            PredefinedTypes.TYPE_NULL), createRecordIterator(errorValue));
-        }
+        return ValueCreator.createStreamValue(
+                TypeCreator.createStreamType(((BTypedesc) recordType).getDescribingType(),
+                        PredefinedTypes.TYPE_NULL), createRecordIterator(errorValue));
     }
 
     private static BObject createRecordIterator(BError errorValue) {

--- a/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/QueryProcessor.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/nativeimpl/QueryProcessor.java
@@ -21,7 +21,7 @@ package org.ballerinalang.sql.nativeimpl;
 import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
-import io.ballerina.runtime.api.types.StructureType;
+import io.ballerina.runtime.api.types.RecordType;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BStream;
@@ -94,14 +94,9 @@ public class QueryProcessor {
                 }
                 resultSet = statement.executeQuery();
                 List<ColumnDefinition> columnDefinitions;
-                StructureType streamConstraint;
-                if (((BTypedesc) recordType).getDescribingType().getName().equals(Constants.DEFAULT_RECORD_NAME)) {
-                    columnDefinitions = Utils.getColumnDefinitions(resultSet, null);
-                    streamConstraint = Utils.getDefaultRecordType(columnDefinitions);
-                } else {
-                    streamConstraint = (StructureType) ((BTypedesc) recordType).getDescribingType();
-                    columnDefinitions = Utils.getColumnDefinitions(resultSet, streamConstraint);
-                }
+                RecordType streamConstraint;
+                streamConstraint = (RecordType) ((BTypedesc) recordType).getDescribingType();
+                columnDefinitions = Utils.getColumnDefinitions(resultSet, streamConstraint);
                 return ValueCreator.createStreamValue(TypeCreator.createStreamType(streamConstraint,
                         PredefinedTypes.TYPE_NULL), resultParameterProcessor
                         .createRecordIterator(resultSet, statement, connection, columnDefinitions, streamConstraint));

--- a/sql-native/src/main/java/org/ballerinalang/sql/utils/Utils.java
+++ b/sql-native/src/main/java/org/ballerinalang/sql/utils/Utils.java
@@ -297,29 +297,28 @@ public class Utils {
             throws ApplicationError {
         String ballerinaFieldName = null;
         Type ballerinaType = null;
-        if (streamConstraint != null) {
-            for (Map.Entry<String, Field> field : streamConstraint.getFields().entrySet()) {
-                if (field.getKey().equalsIgnoreCase(columnName)) {
-                    ballerinaFieldName = field.getKey();
-                    ballerinaType = validFieldConstraint(sqlType, field.getValue().getFieldType());
-                    if (ballerinaType == null) {
-                        throw new ApplicationError("The field '" + field.getKey() + "' of type " +
-                                field.getValue().getFieldType().getName() + " cannot be mapped to the column '" +
-                                columnName + "' of SQL type '" + sqlTypeName + "'");
-                    }
-                    break;
+        for (Map.Entry<String, Field> field : streamConstraint.getFields().entrySet()) {
+            if (field.getKey().equalsIgnoreCase(columnName)) {
+                ballerinaFieldName = field.getKey();
+                ballerinaType = validFieldConstraint(sqlType, field.getValue().getFieldType());
+                if (ballerinaType == null) {
+                    throw new ApplicationError("The field '" + field.getKey() + "' of type " +
+                            field.getValue().getFieldType().getName() + " cannot be mapped to the column '" +
+                            columnName + "' of SQL type '" + sqlTypeName + "'");
                 }
+                break;
             }
-            if (ballerinaFieldName == null) {
+        }
+        if (ballerinaFieldName == null) {
+            if (((RecordType) streamConstraint).isSealed()) {
                 throw new ApplicationError("No mapping field found for SQL table column '" + columnName + "'"
                         + " in the record type '" + streamConstraint.getName() + "'");
+            } else {
+                ballerinaType = getDefaultBallerinaType(sqlType);
+                ballerinaFieldName = columnName;
             }
-        } else {
-            ballerinaType = getDefaultBallerinaType(sqlType);
-            ballerinaFieldName = columnName;
         }
         return new ColumnDefinition(columnName, ballerinaFieldName, sqlType, sqlTypeName, ballerinaType, isNullable);
-
     }
 
     private static boolean isValidFieldConstraint(int sqlType, Type type) {

--- a/sql-test-utils/src/main/java/org/ballerinalang/sql/testutils/QueryTestUtils.java
+++ b/sql-test-utils/src/main/java/org/ballerinalang/sql/testutils/QueryTestUtils.java
@@ -18,9 +18,9 @@
 
 package org.ballerinalang.sql.testutils;
 
-import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BStream;
+import io.ballerina.runtime.api.values.BTypedesc;
 
 import org.ballerinalang.sql.nativeimpl.QueryProcessor;
 import org.ballerinalang.sql.parameterprocessor.DefaultResultParameterProcessor;
@@ -32,7 +32,7 @@ public class QueryTestUtils {
     }
 
     public static BStream nativeQuery(BObject client, Object paramSQLString,
-                                      Object recordType) {
+                                      BTypedesc recordType) {
         DefaultStatementParameterProcessor statementParametersProcessor = DefaultStatementParameterProcessor
                 .getInstance();
         DefaultResultParameterProcessor resultParametersProcessor = DefaultResultParameterProcessor


### PR DESCRIPTION
## Purpose
$title
Earlier, when getting a result set from the `query` remote method of the `jdbc` client, the ballerina developer first has to get the `resultStream` as `stream<record{}, error>` even the return type is provided. Then only developer can cast it to intended `resultStream`. 

Fixes for:
 https://github.com/ballerina-platform/ballerina-standard-library/issues/1445
 https://github.com/ballerina-platform/ballerina-standard-library/issues/1174


## Examples

Earlier implementation

```ballerina
type Customer record {|
    int customerId;
    string lastName;
    string firstName;
    int registrationId;
    float creditLimit;
    string country;
|};

jdbc:Client jdbcClient = check new ("jdbc:h2:file:./target/bbes/java_jdbc",
        "rootUser", "rootPass");

stream<record{}, error> resultStream =
        jdbcClient->query(`SELECT * FROM Customers`, Customer);

stream<Customer, sql:Error> customerStream =
        <stream<Customer, sql:Error>>resultStream;

e = customerStream.forEach(function(Customer customer) {
        io:println("Full Customer details: ", customer);
    });
```

new implementation 

```ballerina
type Customer record {|
    int customerId;
    string lastName;
    string firstName;
    int registrationId;
    float creditLimit;
    string country;
|};

jdbc:Client jdbcClient = check new ("jdbc:h2:file:./target/bbes/java_jdbc",
        "rootUser", "rootPass");

stream<Customer, error> customerStream =
        jdbcClient->query(`SELECT * FROM Customers`);

e = customerStream.forEach(function(Customer customer) {
        io:println("Full Customer details: ", customer);
    });

```


## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests