### PR TITLE
Change UTC return type for output parameters to correspond to local timezone

### DIFF
--- a/ballerina/tests/call-procedures-test.bal
+++ b/ballerina/tests/call-procedures-test.bal
@@ -448,6 +448,36 @@ function testCallWithDateTimeTypeRecordsWithOutParams() returns error? {
     test:assertEquals(paraTimestampWithTz.get(time:Civil), timestampWithTzRecord, "Timestamp with Timezone out parameter of procedure did not match.");
 }
 
+@test:Config {
+    groups: ["procedures"],
+    dependsOn: [testCreateProcedures6]
+}
+function testCallWithTimestamptzRetrievalWithOutParams() returns error? {
+    IntegerValue paraID = new(1);
+    DateOutParameter paraDate = new;
+    TimeOutParameter paraTime = new;
+    DateTimeOutParameter paraDateTime = new;
+    TimeWithTimezoneOutParameter paraTimeWithTz = new;
+    TimestampOutParameter paraTimestamp = new;
+    TimestampWithTimezoneOutParameter paraTimestampWithTz = new;
+
+    ParameterizedCallQuery callProcedureQuery = `call SelectDateTimeDataWithOutParams(${paraID}, ${paraDate},
+                                    ${paraTime}, ${paraDateTime}, ${paraTimeWithTz}, ${paraTimestamp}, ${paraTimestampWithTz})`;
+
+    ProcedureCallResult ret = check getProcedureCallResultFromMockClient(callProcedureQuery);
+    check ret.close();
+
+    string timestampWithTzRecordString = "2017-01-25T16:33:55-08:00";
+    time:Civil timestampWithTzRecordCivil = {utcOffset: {hours: -8, minutes: 0}, timeAbbrev: "-08:00", year:2017,
+                                        month:1, day:25, hour: 16, minute: 33, second:55};
+    time:Utc timestampWithTzRecordUtc = check time:utcFromCivil(timestampWithTzRecordCivil);
+
+    test:assertEquals(paraTimestampWithTz.get(string), timestampWithTzRecordString, "Timestamp with Timezone out parameter of procedure did not match.");
+    test:assertEquals(paraTimestampWithTz.get(time:Civil), timestampWithTzRecordCivil, "Timestamp with Timezone out parameter of procedure did not match.");
+    test:assertEquals(paraTimestampWithTz.get(time:Utc), timestampWithTzRecordUtc, "Timestamp with Timezone out parameter of procedure did not match.");
+}
+
+
 type IntArray int[];
 type StringArray string[];
 

--- a/ballerina/tests/call-procedures-test.bal
+++ b/ballerina/tests/call-procedures-test.bal
@@ -284,7 +284,7 @@ function testCallWithNumericTypesInoutParams() returns error? {
 
 @test:Config {
     groups: ["procedures"],
-    dependsOn: [testCallWithStringTypesInoutParams,testCreateProcedures8]
+    dependsOn: [testCallWithStringTypesInoutParams, testCreateProcedures9]
 }
 function testCallWithAllTypesInoutParamsAsObjectValues() returns error? {
     IntegerValue paraID = new(1);
@@ -450,19 +450,13 @@ function testCallWithDateTimeTypeRecordsWithOutParams() returns error? {
 
 @test:Config {
     groups: ["procedures"],
-    dependsOn: [testCreateProcedures6]
+    dependsOn: [testCreateProcedures7]
 }
 function testCallWithTimestamptzRetrievalWithOutParams() returns error? {
     IntegerValue paraID = new(1);
-    DateOutParameter paraDate = new;
-    TimeOutParameter paraTime = new;
-    DateTimeOutParameter paraDateTime = new;
-    TimeWithTimezoneOutParameter paraTimeWithTz = new;
-    TimestampOutParameter paraTimestamp = new;
     TimestampWithTimezoneOutParameter paraTimestampWithTz = new;
 
-    ParameterizedCallQuery callProcedureQuery = `call SelectDateTimeDataWithOutParams(${paraID}, ${paraDate},
-                                    ${paraTime}, ${paraDateTime}, ${paraTimeWithTz}, ${paraTimestamp}, ${paraTimestampWithTz})`;
+    ParameterizedCallQuery callProcedureQuery = `call SelectTimestamptzWithOutParams(${paraID}, ${paraTimestampWithTz})`;
 
     ProcedureCallResult ret = check getProcedureCallResultFromMockClient(callProcedureQuery);
     check ret.close();
@@ -483,7 +477,7 @@ type StringArray string[];
 
 @test:Config {
     groups: ["procedures"],
-    dependsOn: [testCreateProcedures7]
+    dependsOn: [testCreateProcedures8]
 }
 function testCallWithOtherDataTypesWithOutParams() returns error? {
     IntegerValue paraID = new(1);
@@ -525,7 +519,7 @@ distinct class RandomOutParameter {
 
 @test:Config {
     groups: ["procedures"],
-    dependsOn: [testCreateProcedures7]
+    dependsOn: [testCreateProcedures8]
 }
 function testCallWithOtherDataTypesWithInvalidOutParams() returns error? {
     IntegerValue paraID = new(1);
@@ -689,9 +683,26 @@ function testCreateProcedures6() returns error? {
 }
 
 @test:Config {
-    groups: ["procedures"]
+    groups: ["procedures"],
+    dependsOn: [testCreateProcedures6]
 }
 function testCreateProcedures7() returns error? {
+    ParameterizedQuery createProcedure = `
+        CREATE PROCEDURE SelectTimestamptzWithOutParams (IN p_id INT, OUT p_timestampwithtz_type TIMESTAMP WITH TIME ZONE)
+            READS SQL DATA DYNAMIC RESULT SETS 2
+            BEGIN ATOMIC
+                SELECT timestampwithtz_type INTO p_timestampwithtz_type FROM DateTimeTypes where id = p_id;
+            END
+        `;
+    validateProcedureResult(check createSqlProcedure(createProcedure),0,());
+}
+
+
+@test:Config {
+    groups: ["procedures"],
+    dependsOn: [testCreateProcedures7]
+}
+function testCreateProcedures8() returns error? {
     ParameterizedQuery createProcedure = `
         CREATE PROCEDURE SelectOtherDataTypesWithOutParams (IN p_id INT, OUT p_clob_type CLOB,
                                                 OUT p_var_binary_type VARBINARY(27), OUT p_int_array_type INT ARRAY,
@@ -711,10 +722,9 @@ function testCreateProcedures7() returns error? {
 }
 
 @test:Config {
-    groups: ["procedures"],
-    dependsOn: [testCreateProcedures7]
+    groups: ["procedures"]
 }
-function testCreateProcedures8() returns error? {
+function testCreateProcedures9() returns error? {
     ParameterizedQuery createProcedure = `
         CREATE PROCEDURE SelectOtherDataWithInoutParams (IN p_id INT, INOUT p_varchar_type VARCHAR(255), INOUT p_char_type CHAR,
                 INOUT p_nvarcharmax_type NVARCHAR(255), INOUT p_bit_type BIT, INOUT p_boolean_type BOOLEAN, INOUT p_int_type INT,

--- a/native/src/main/java/io/ballerina/stdlib/sql/parameterprocessor/DefaultResultParameterProcessor.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/parameterprocessor/DefaultResultParameterProcessor.java
@@ -54,6 +54,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -663,7 +664,8 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
                 case TypeTags.INT_TAG:
                     return Timestamp.valueOf(offsetDateTime.toLocalDateTime()).getTime();
                 case TypeTags.INTERSECTION_TAG:
-                    return Utils.createTimeStruct(Timestamp.valueOf(offsetDateTime.toLocalDateTime()).getTime());
+                    return Utils.createTimeStruct(Timestamp.valueOf(
+                            offsetDateTime.atZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime()).getTime());
             }
         }
         return null;


### PR DESCRIPTION
## Purpose
In the current implementation of output parameter retrieval of timestamp with timezone, the timezone information was dropped off and only the date & time were returned. This resulted in incorrect UTC values being generated if the stored timezone is different from the local timezone.

This fix first converts the timestamp into the local timezone and returns the correct datetime in UTC. 

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1693

Tested with MySQL, PostgreSQL and MSSQL modules.

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests