### PR TITLE
Cap the maximum thread that can be created by bal-sql-thread factory

### DIFF
--- a/native/src/main/java/io/ballerina/stdlib/sql/datasource/SQLWorkerThreadPool.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/datasource/SQLWorkerThreadPool.java
@@ -19,8 +19,10 @@
 package io.ballerina.stdlib.sql.datasource;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Class to hold the static cachedThreadPool for SQL.
@@ -30,7 +32,9 @@ public class SQLWorkerThreadPool {
     private SQLWorkerThreadPool(){
     }
 
-    public static final ExecutorService SQL_EXECUTOR_SERVICE = Executors.newCachedThreadPool(new SQLThreadFactory());
+    // This is similar to cachedThreadPool util from Executors.newCachedThreadPool(..); but with upper cap on threads
+    public static final ExecutorService SQL_EXECUTOR_SERVICE =  new ThreadPoolExecutor(0, 50,
+            60L, TimeUnit.SECONDS, new SynchronousQueue<>(), new SQLThreadFactory());
 
     static class SQLThreadFactory implements ThreadFactory {
         @Override


### PR DESCRIPTION
## Purpose
Fine-tune the asynchronous thread pool with a maximum number of threads that can be created.

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1764

## Examples

## Checklist
- [x] Linked to an issue
- [ ] ~Updated the changelog~
- [ ] ~Added tests~