### PR TITLE
Add flags for requesting auto generated keys on query execution

### DIFF
--- a/native/src/main/java/io/ballerina/stdlib/sql/datasource/SQLDatasource.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/datasource/SQLDatasource.java
@@ -151,7 +151,6 @@ public class SQLDatasource {
                     key -> createAndInitDatasource(sqlDatasourceParams));
 
         }
-
         sqlDatasourceToBeReturned.setExecuteGKFlag(executeGKFlag);
         sqlDatasourceToBeReturned.setBatchExecuteGKFlag(batchExecuteGKFlag);
         return sqlDatasourceToBeReturned;
@@ -436,7 +435,6 @@ public class SQLDatasource {
     public boolean getBatchExecuteGKFlag() {
         return this.batchExecuteGKFlag;
     }
-
 
     /**
      * This class encapsulates the parameters required for the initialization of {@code SQLDatasource} class.

--- a/native/src/main/java/io/ballerina/stdlib/sql/datasource/SQLDatasource.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/datasource/SQLDatasource.java
@@ -59,6 +59,8 @@ public class SQLDatasource {
     private AtomikosDataSourceBean atomikosDataSourceBean;
     private HikariDataSource hikariDataSource;
     private XADataSource xaDataSource;
+    private boolean executeGKFlag;
+    private boolean batchExecuteGKFlag;
     private static final String POOL_MAP_KEY = UUID.randomUUID().toString();
 
     private SQLDatasource(SQLDatasourceParams sqlDatasourceParams) {
@@ -121,7 +123,8 @@ public class SQLDatasource {
      *                            initialization of the newly created datasource if it doesn't exists
      * @return The existing or newly created {@link SQLDatasource} object
      */
-    public static SQLDatasource retrieveDatasource(SQLDatasource.SQLDatasourceParams sqlDatasourceParams) {
+    public static SQLDatasource retrieveDatasource(SQLDatasource.SQLDatasourceParams sqlDatasourceParams,
+                                                   boolean executeGKFlag, boolean batchExecuteGKFlag) {
         PoolKey poolKey = new PoolKey(sqlDatasourceParams.url, sqlDatasourceParams.options);
         Map<PoolKey, SQLDatasource> hikariDatasourceMap = (Map<PoolKey, SQLDatasource>) sqlDatasourceParams
                 .connectionPool.getNativeData(POOL_MAP_KEY);
@@ -148,6 +151,9 @@ public class SQLDatasource {
                     key -> createAndInitDatasource(sqlDatasourceParams));
 
         }
+
+        sqlDatasourceToBeReturned.setExecuteGKFlag(executeGKFlag);
+        sqlDatasourceToBeReturned.setBatchExecuteGKFlag(batchExecuteGKFlag);
         return sqlDatasourceToBeReturned;
     }
 
@@ -414,6 +420,23 @@ public class SQLDatasource {
         }
         return message.toString();
     }
+
+    public void setExecuteGKFlag(boolean flag) {
+        this.executeGKFlag = flag;
+    }
+
+    public void setBatchExecuteGKFlag(boolean flag) {
+        this.batchExecuteGKFlag = flag;
+    }
+
+    public boolean getExecuteGKFlag() {
+        return this.executeGKFlag;
+    }
+
+    public boolean getBatchExecuteGKFlag() {
+        return this.batchExecuteGKFlag;
+    }
+
 
     /**
      * This class encapsulates the parameters required for the initialization of {@code SQLDatasource} class.

--- a/native/src/main/java/io/ballerina/stdlib/sql/datasource/SQLDatasource.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/datasource/SQLDatasource.java
@@ -420,11 +420,11 @@ public class SQLDatasource {
         return message.toString();
     }
 
-    public void setExecuteGKFlag(boolean flag) {
+    private void setExecuteGKFlag(boolean flag) {
         this.executeGKFlag = flag;
     }
 
-    public void setBatchExecuteGKFlag(boolean flag) {
+    private void setBatchExecuteGKFlag(boolean flag) {
         this.batchExecuteGKFlag = flag;
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/sql/nativeimpl/ClientProcessor.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/nativeimpl/ClientProcessor.java
@@ -55,10 +55,12 @@ public class ClientProcessor {
      *                            initialization of the newly created datasource if it doesn't exists
      * @return null if client is successfully created else error         
      */
-    public static Object createClient(BObject client, SQLDatasource.SQLDatasourceParams sqlDatasourceParams) {
+    public static Object createClient(BObject client, SQLDatasource.SQLDatasourceParams sqlDatasourceParams,
+                                      boolean executeGKFlag, boolean batchExecuteGKFlag) {
         try {
             LogManager.getLogManager().reset();
-            SQLDatasource sqlDatasource = SQLDatasource.retrieveDatasource(sqlDatasourceParams);
+            SQLDatasource sqlDatasource = SQLDatasource.retrieveDatasource(sqlDatasourceParams, executeGKFlag,
+                                                                           batchExecuteGKFlag);
             client.addNativeData(Constants.DATABASE_CLIENT, sqlDatasource);
             client.addNativeData(Constants.SQL_CONNECTOR_TRANSACTION_ID, UUID.randomUUID().toString());
             client.addNativeData(Constants.DATABASE_CLIENT_ACTIVE_STATUS, Boolean.TRUE);

--- a/native/src/main/java/io/ballerina/stdlib/sql/nativeimpl/ExecuteProcessor.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/nativeimpl/ExecuteProcessor.java
@@ -174,33 +174,6 @@ public class ExecuteProcessor {
         return null;
     }
 
-    /**
-     * Execute a batch of SQL statements.
-     * @param client client object
-     * @param paramSQLStrings array of SQL string for the execute statement
-     * @param statementParameterProcessor pre-processor of the statement
-     * @param generateKeys flag to auto-generate keys
-     * @return execution result or error
-     */
-    public static Object nativeBatchExecute(Environment env, BObject client, BArray paramSQLStrings,
-                                            AbstractStatementParameterProcessor statementParameterProcessor,
-                                            boolean generateKeys) {
-        TransactionResourceManager trxResourceManager = TransactionResourceManager.getInstance();
-        if (!Utils.isWithinTrxBlock(trxResourceManager)) {
-            Future balFuture = env.markAsync();
-            SQL_EXECUTOR_SERVICE.execute(()-> {
-                Object resultStream =
-                        nativeBatchExecuteExecutable(client, paramSQLStrings, statementParameterProcessor,
-                                false, null);
-                balFuture.complete(resultStream);
-            });
-        } else {
-            return nativeBatchExecuteExecutable(client, paramSQLStrings, statementParameterProcessor,
-                    true, trxResourceManager);
-        }
-        return null;
-    }
-
     private static Object nativeBatchExecuteExecutable(BObject client, BArray paramSQLStrings,
                                             AbstractStatementParameterProcessor statementParameterProcessor,
                                             boolean isWithinTrxBlock, TransactionResourceManager trxResourceManager) {

--- a/native/src/main/java/io/ballerina/stdlib/sql/nativeimpl/ExecuteProcessor.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/nativeimpl/ExecuteProcessor.java
@@ -111,7 +111,13 @@ public class ExecuteProcessor {
                     sqlQuery = getSqlQuery((BObject) paramSQLString);
                 }
                 connection = SQLDatasource.getConnection(isWithInTrxBlock, trxResourceManager, client, sqlDatasource);
-                statement = connection.prepareStatement(sqlQuery, Statement.RETURN_GENERATED_KEYS);
+
+                if (sqlDatasource.getExecuteGKFlag()) {
+                    statement = connection.prepareStatement(sqlQuery, Statement.RETURN_GENERATED_KEYS);
+                } else {
+                    statement = connection.prepareStatement(sqlQuery);
+                }
+
                 if (paramSQLString instanceof BObject) {
                     statementParameterProcessor.setParams(connection, statement, (BObject) paramSQLString);
                 }
@@ -157,12 +163,12 @@ public class ExecuteProcessor {
             Future balFuture = env.markAsync();
             SQL_EXECUTOR_SERVICE.execute(()-> {
                 Object resultStream =
-                        nativeBatchExecuteExecutable(client, paramSQLStrings, statementParameterProcessor, true,
+                        nativeBatchExecuteExecutable(client, paramSQLStrings, statementParameterProcessor,
                                 false, null);
                 balFuture.complete(resultStream);
             });
         } else {
-            return nativeBatchExecuteExecutable(client, paramSQLStrings, statementParameterProcessor, true,
+            return nativeBatchExecuteExecutable(client, paramSQLStrings, statementParameterProcessor,
                     true, trxResourceManager);
         }
         return null;
@@ -184,12 +190,12 @@ public class ExecuteProcessor {
             Future balFuture = env.markAsync();
             SQL_EXECUTOR_SERVICE.execute(()-> {
                 Object resultStream =
-                        nativeBatchExecuteExecutable(client, paramSQLStrings, statementParameterProcessor, generateKeys,
+                        nativeBatchExecuteExecutable(client, paramSQLStrings, statementParameterProcessor,
                                 false, null);
                 balFuture.complete(resultStream);
             });
         } else {
-            return nativeBatchExecuteExecutable(client, paramSQLStrings, statementParameterProcessor, generateKeys,
+            return nativeBatchExecuteExecutable(client, paramSQLStrings, statementParameterProcessor,
                     true, trxResourceManager);
         }
         return null;
@@ -197,8 +203,7 @@ public class ExecuteProcessor {
 
     private static Object nativeBatchExecuteExecutable(BObject client, BArray paramSQLStrings,
                                             AbstractStatementParameterProcessor statementParameterProcessor,
-                                            boolean generateKeys, boolean isWithinTrxBlock,
-                                            TransactionResourceManager trxResourceManager) {
+                                            boolean isWithinTrxBlock, TransactionResourceManager trxResourceManager) {
         Object dbClient = client.getNativeData(Constants.DATABASE_CLIENT);
         if (dbClient != null) {
             SQLDatasource sqlDatasource = (SQLDatasource) dbClient;
@@ -207,11 +212,11 @@ public class ExecuteProcessor {
                         " are not allowed");
             }
             if (paramSQLStrings.getElementType().getTag() == TypeTags.STRING_TAG) {
-                return batchExecuteMultipleQueries(client, sqlDatasource, paramSQLStrings, generateKeys,
-                        isWithinTrxBlock, trxResourceManager);
+                return batchExecuteMultipleQueries(client, sqlDatasource, paramSQLStrings, isWithinTrxBlock,
+                        trxResourceManager);
             } else {
                 return batchExecuteParameterizedQuery(client, sqlDatasource, paramSQLStrings,
-                        statementParameterProcessor, generateKeys, isWithinTrxBlock, trxResourceManager);
+                        statementParameterProcessor, isWithinTrxBlock, trxResourceManager);
             }
         } else {
             return ErrorGenerator.getSQLApplicationError(
@@ -222,7 +227,7 @@ public class ExecuteProcessor {
     private static Object batchExecuteParameterizedQuery(BObject client, SQLDatasource sqlDatasource,
                                                          BArray paramSQLStrings,
                                                          AbstractStatementParameterProcessor statementParamProcessor,
-                                                         boolean generateKeys, boolean isWithinTrxBlock,
+                                                         boolean isWithinTrxBlock,
                                                          TransactionResourceManager trxResourceManager) {
         Connection connection = null;
         PreparedStatement statement = null;
@@ -248,7 +253,7 @@ public class ExecuteProcessor {
             }
             connection = SQLDatasource.getConnection(isWithinTrxBlock, trxResourceManager, client, sqlDatasource);
 
-            if (generateKeys) {
+            if (sqlDatasource.getBatchExecuteGKFlag()) {
                 statement = connection.prepareStatement(sqlQuery, Statement.RETURN_GENERATED_KEYS);
             } else {
                 statement = connection.prepareStatement(sqlQuery, Statement.NO_GENERATED_KEYS);
@@ -261,7 +266,7 @@ public class ExecuteProcessor {
 
             int[] counts = statement.executeBatch();
 
-            if (generateKeys && !isDdlStatement(sqlQuery)) {
+            if (sqlDatasource.getBatchExecuteGKFlag() && !isDdlStatement(sqlQuery)) {
                 resultSet = statement.getGeneratedKeys();
             }
             for (int count : counts) {
@@ -301,8 +306,7 @@ public class ExecuteProcessor {
     }
 
     private static Object batchExecuteMultipleQueries(BObject client, SQLDatasource sqlDatasource,
-                                                      BArray paramSQLStrings, boolean generateKeys,
-                                                      boolean isWithinTrxBlock,
+                                                      BArray paramSQLStrings, boolean isWithinTrxBlock,
                                                       TransactionResourceManager trxResourceManager) {
         Connection connection = null;
         Statement statement = null;
@@ -321,7 +325,7 @@ public class ExecuteProcessor {
             }
             int[] counts = statement.executeBatch();
 
-            if (generateKeys) {
+            if (sqlDatasource.getBatchExecuteGKFlag()) {
                 resultSet = statement.getGeneratedKeys();
             }
             for (int count : counts) {

--- a/test-utils/src/main/java/io/ballerina/stdlib/sql/testutils/ClientTestUtils.java
+++ b/test-utils/src/main/java/io/ballerina/stdlib/sql/testutils/ClientTestUtils.java
@@ -35,7 +35,7 @@ public class ClientTestUtils {
     public static Object createSqlClient(BObject client, BMap<BString, Object> sqlDatasourceParams,
                                          BMap<BString, Object> globalConnectionPool) {
         return ClientProcessor.createClient(client,
-                SQLDatasource.createSQLDatasourceParams(sqlDatasourceParams, globalConnectionPool));
+                SQLDatasource.createSQLDatasourceParams(sqlDatasourceParams, globalConnectionPool), true , true);
     }
 
     public static Object close(BObject client) {

--- a/test-utils/src/main/java/io/ballerina/stdlib/sql/testutils/ClientTestUtils.java
+++ b/test-utils/src/main/java/io/ballerina/stdlib/sql/testutils/ClientTestUtils.java
@@ -35,7 +35,7 @@ public class ClientTestUtils {
     public static Object createSqlClient(BObject client, BMap<BString, Object> sqlDatasourceParams,
                                          BMap<BString, Object> globalConnectionPool) {
         return ClientProcessor.createClient(client,
-                SQLDatasource.createSQLDatasourceParams(sqlDatasourceParams, globalConnectionPool), true , true);
+                SQLDatasource.createSQLDatasourceParams(sqlDatasourceParams, globalConnectionPool), true, true);
     }
 
     public static Object close(BObject client) {


### PR DESCRIPTION
## Purpose
On SQL client initialization, two flags need to be passed to define whether Auto Generated Keys should be retrieved when executing queries.

Related issue: https://github.com/ballerina-platform/ballerina-standard-library/issues/1804

Related PR for JDBC: https://github.com/ballerina-platform/module-ballerinax-java.jdbc/pull/245

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests