### PR TITLE
Change  HSQLDB docker image used in test containers

### DIFF
--- a/ballerina/tests/utils.bal
+++ b/ballerina/tests/utils.bal
@@ -45,7 +45,7 @@ function initializeDockerContainer(string containerName, string dbAlias, string 
         "-e", "HSQLDB_DATABASE_ALIAS=" + dbAlias, 
         "-e", "HSQLDB_USER=test", 
         "-v", check file:joinPath(scriptPath, resFolder) + ":/scripts", 
-        "-p", port + ":9001", "blacklabelops/hsqldb");
+        "-p", port + ":9001", "kaneeldias/hsqldb");
     Process result = check execResult;
     int waitForExit = check result.waitForExit();
     exitCode = check result.exitCode();


### PR DESCRIPTION
## Purpose
The [previous docker image](https://hub.docker.com/r/blacklabelops/hsqldb) used for HSQLDB only supported `linux/amd64` architectures. The [new docker image](https://hub.docker.com/r/kaneeldias/hsqldb) supports both `linux/amd64` and `linux/arm64` architectures.

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1865

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests