### PR TITLE
Add support for passing ballerina UTC and civil types in parameterized queries

### DIFF
--- a/ballerina/tests/execute-params-query-test.bal
+++ b/ballerina/tests/execute-params-query-test.bal
@@ -25,7 +25,7 @@ string executeParamsDb = urlPrefix + "9007/executeparams";
     value: ["execute-params"]
 }
 function initExecuteParamsContainer() returns error? {
-    check initializeDockerContainer("sql-execute-params", "executeparams", "9007", "execute", "execute-params-test-data.sql");
+   check initializeDockerContainer("sql-execute-params", "executeparams", "9007", "execute", "execute-params-test-data.sql");
 }
 
 @test:AfterGroups {
@@ -353,6 +353,31 @@ function insertIntoDateTimeTable4() returns error? {
     ParameterizedQuery sqlQuery = 
             `INSERT INTO DateTimeTypes (row_id, date_type, time_type, datetime_type, timestamp_type)
             VALUES(${rowId}, ${nilType}, ${nilType}, ${nilType}, ${nilType})`;
+    validateResult(check executeQueryMockClient(sqlQuery), 1);
+}
+
+@test:Config {
+    groups: ["execute", "execute-params"]
+}
+function insertIntoDateTimeTable5() returns error? {
+    int rowId = 6;
+    time:Utc currentTime = time:utcNow();
+    time:Civil currentCivil = time:utcToCivil(currentTime);
+
+    ParameterizedQuery sqlQuery =
+            `INSERT INTO DateTimeTypes (row_id, datetime_type) VALUES(${rowId}, ${currentCivil})`;
+    validateResult(check executeQueryMockClient(sqlQuery), 1);
+}
+
+@test:Config {
+    groups: ["execute", "execute-params"]
+}
+function insertIntoDateTimeTable6() returns error? {
+    int rowId = 7;
+    time:Utc currentTime = time:utcNow();
+
+    ParameterizedQuery sqlQuery =
+            `INSERT INTO DateTimeTypes (row_id, datetime_type) VALUES(${rowId}, ${currentTime})`;
     validateResult(check executeQueryMockClient(sqlQuery), 1);
 }
 

--- a/ballerina/tests/execute-params-query-test.bal
+++ b/ballerina/tests/execute-params-query-test.bal
@@ -25,7 +25,7 @@ string executeParamsDb = urlPrefix + "9007/executeparams";
     value: ["execute-params"]
 }
 function initExecuteParamsContainer() returns error? {
-   check initializeDockerContainer("sql-execute-params", "executeparams", "9007", "execute", "execute-params-test-data.sql");
+    check initializeDockerContainer("sql-execute-params", "executeparams", "9007", "execute", "execute-params-test-data.sql");
 }
 
 @test:AfterGroups {

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- [Add support for passing time:UTC type directly into parameterized queries](https://github.com/ballerina-platform/ballerina-standard-library/issues/1800)
+- [Add support for passing time:Civil type directly into parameterized queries](https://github.com/ballerina-platform/ballerina-standard-library/issues/1799)
 - [Improve Errors](https://github.com/ballerina-platform/ballerina-standard-library/issues/1758)
 - [Improve the Batchupdate query to support string[]](https://github.com/ballerina-platform/ballerina-standard-library/issues/1529)
 - [Add support for async operation](https://github.com/ballerina-platform/ballerina-standard-library/issues/120)

--- a/native/src/main/java/io/ballerina/stdlib/sql/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/Constants.java
@@ -185,6 +185,8 @@ public final class Constants {
         public static final String BYTE_ARRAY_TYPE = "byte[]";
         public static final String CIVIL_ARRAY_TYPE = "time:Civil";
         public static final String TIME_OF_DAY_ARRAY_TYPE = "time:TimeOfDay";
+        public static final String CIVIL = "Civil";
+        public static final String UTC = "[int,decimal] & readonly";
     }
 
     /**

--- a/native/src/main/java/io/ballerina/stdlib/sql/parameterprocessor/AbstractStatementParameterProcessor.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/parameterprocessor/AbstractStatementParameterProcessor.java
@@ -225,10 +225,7 @@ public abstract class AbstractStatementParameterProcessor {
         } else if (object instanceof BMap) {
             BMap mapValue = (BMap) object;
             setBMapParams(connection, preparedStatement, index, mapValue, returnType);
-            if (returnType) {
-                return getSQLType(mapValue);
-            }
-            return 0;
+            return getSQLType(mapValue);
         } else {
             throw new DataError("Unsupported type passed in column index: " + index);
         }

--- a/native/src/main/java/io/ballerina/stdlib/sql/parameterprocessor/DefaultStatementParameterProcessor.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/parameterprocessor/DefaultStatementParameterProcessor.java
@@ -29,7 +29,6 @@ import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BDecimal;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
-import io.ballerina.runtime.api.values.BRefValue;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.api.values.BXml;
 import io.ballerina.stdlib.io.channels.base.Channel;
@@ -825,7 +824,7 @@ public class DefaultStatementParameterProcessor extends AbstractStatementParamet
         throw new DataError("Unsupported OutParameter type: " + sqlType);
     }
 
-    protected int getCustomSQLType(BRefValue typedValue) throws DataError {
+    protected int getCustomSQLType(BObject typedValue) throws DataError {
         String sqlType = typedValue.getType().getName();
         throw new DataError("Unsupported SQL type: " + sqlType);
     }

--- a/native/src/main/java/io/ballerina/stdlib/sql/parameterprocessor/DefaultStatementParameterProcessor.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/parameterprocessor/DefaultStatementParameterProcessor.java
@@ -29,6 +29,7 @@ import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BDecimal;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
+import io.ballerina.runtime.api.values.BRefValue;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.api.values.BXml;
 import io.ballerina.stdlib.io.channels.base.Channel;
@@ -614,7 +615,7 @@ public class DefaultStatementParameterProcessor extends AbstractStatementParamet
 
     @Override
     protected int setCustomBOpenRecord(Connection connection, PreparedStatement preparedStatement, int index,
-                                      Object value, boolean returnType) throws DataError, SQLException {
+                                      Object value, boolean returnType) throws DataError {
         throw new DataError("Unsupported type passed in column index: " + index);
     }
 
@@ -824,7 +825,7 @@ public class DefaultStatementParameterProcessor extends AbstractStatementParamet
         throw new DataError("Unsupported OutParameter type: " + sqlType);
     }
 
-    protected int getCustomSQLType(BObject typedValue) throws DataError {
+    protected int getCustomSQLType(BRefValue typedValue) throws DataError {
         String sqlType = typedValue.getType().getName();
         throw new DataError("Unsupported SQL type: " + sqlType);
     }

--- a/native/src/main/java/io/ballerina/stdlib/sql/parameterprocessor/DefaultStatementParameterProcessor.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/parameterprocessor/DefaultStatementParameterProcessor.java
@@ -615,7 +615,7 @@ public class DefaultStatementParameterProcessor extends AbstractStatementParamet
 
     @Override
     protected int setCustomBOpenRecord(Connection connection, PreparedStatement preparedStatement, int index,
-                                      Object value, boolean returnType) throws DataError {
+                                      Object value, boolean returnType) throws DataError, SQLException {
         throw new DataError("Unsupported type passed in column index: " + index);
     }
 


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1799
Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1800

## Examples
**Civil Type**
```
time:Utc currentTime = time:utcNow();
time:Civil currentCivil = time:utcToCivil(currentTime);
ParameterizedQuery sqlQuery =
            `INSERT INTO DateTimeTypes (row_id, datetime_type) VALUES(${rowId}, ${currentCivil})`;
dbClient->execute(sqlQuery)
```

**UTC Type**
```
time:Utc currentTime = time:utcNow();
ParameterizedQuery sqlQuery =
            `INSERT INTO DateTimeTypes (row_id, datetime_type) VALUES(${rowId}, ${currentTime})`;
dbClient->execute(sqlQuery)
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests