### PR TITLE
Add support for retrieving time:Utc type

### DIFF
--- a/ballerina/tests/complex-query-test.bal
+++ b/ballerina/tests/complex-query-test.bal
@@ -464,6 +464,31 @@ function testDateTime3() returns error? {
     check dbClient.close();
 }
 
+@test:Config {
+    groups: ["query", "query-complex-params"]
+}
+function testDateTime4() returns error? {
+    time:Civil timestampWithTimezone = {
+            utcOffset: {hours: -8, minutes: 0},
+            timeAbbrev: "-08:00",
+            year: 2017,
+            month: 1,
+            day: 25,
+            hour: 16,
+            minute: 33,
+            second: 55
+    };
+    time:Utc timeUtc = check time:utcFromCivil(timestampWithTimezone);
+
+    MockClient dbClient = check new (url = complexQueryDb, user = user, password = password);
+    time:Utc retrievedTimeUtc = check dbClient->queryRow(`
+        SELECT timestamp_tz_type from DateTimeTypes where row_id = 1
+    `);
+    check dbClient.close();
+
+    test:assertEquals(retrievedTimeUtc, timeUtc, "Expected UTC timestamp did not match.");
+}
+
 type ResultSetTestAlias record {
     int int_type;
     int long_type;

--- a/ballerina/tests/execute-params-query-test.bal
+++ b/ballerina/tests/execute-params-query-test.bal
@@ -419,7 +419,17 @@ function insertIntoDateTimeTable5() returns error? {
 }
 function insertIntoDateTimeTable6() returns error? {
     int rowId = 7;
-    time:Utc timeUtc = time:utcNow();
+    time:Civil timeCivil = {
+        utcOffset: {hours: -8, minutes: 0},
+        timeAbbrev: "-08:00",
+        year: 2017,
+        month: 1,
+        day: 25,
+        hour: 16,
+        minute: 33,
+        second: 55
+    };
+    time:Utc timeUtc = check time:utcFromCivil(timeCivil);
 
     ParameterizedQuery sqlQuery =
             `INSERT INTO DateTimeTypes (row_id, timestamp_tz_type) VALUES(${rowId}, ${timeUtc})`;
@@ -431,9 +441,7 @@ function insertIntoDateTimeTable6() returns error? {
     `);
     check dbClient.close();
 
-    // The two values will not be equal since only upto 3 decimal places of seconds are stored in the database.
-    test:assertTrue(time:utcDiffSeconds(timeUtc, retrievedTimeUtc) < <decimal>0.001,
-        "Inserted data did not match retrieved data.");
+    test:assertEquals(retrievedTimeUtc, timeUtc, "Inserted data did not match retrieved data.");
 }
 
 @test:Config {

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- [Add support for retrieving time:Utc type](https://github.com/ballerina-platform/ballerina-standard-library/issues/1909)
 - [Add support for passing time:Date and time:TimeOfDay types directly into parameterized queries](https://github.com/ballerina-platform/ballerina-standard-library/issues/1891)
 - [Add support for passing time:UTC type directly into parameterized queries](https://github.com/ballerina-platform/ballerina-standard-library/issues/1800)
 - [Add support for passing time:Civil type directly into parameterized queries](https://github.com/ballerina-platform/ballerina-standard-library/issues/1799)

--- a/native/src/main/java/io/ballerina/stdlib/sql/parameterprocessor/DefaultResultParameterProcessor.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/parameterprocessor/DefaultResultParameterProcessor.java
@@ -544,6 +544,7 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
                 case TypeTags.INT_TAG:
                     return timestamp.getTime();
                 case TypeTags.INTERSECTION_TAG:
+                case TypeTags.TUPLE_TAG:
                     return Utils.createTimeStruct(timestamp.getTime());
             }
         }
@@ -568,6 +569,7 @@ public class DefaultResultParameterProcessor extends AbstractResultParameterProc
                 case TypeTags.INT_TAG:
                     return Timestamp.valueOf(offsetDateTime.toLocalDateTime()).getTime();
                 case TypeTags.INTERSECTION_TAG:
+                case TypeTags.TUPLE_TAG:
                     return Utils.createTimeStruct(Timestamp.valueOf(
                             offsetDateTime.atZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime()).getTime());
             }

--- a/native/src/main/java/io/ballerina/stdlib/sql/utils/Utils.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/utils/Utils.java
@@ -554,7 +554,8 @@ public class Utils {
                         type.getTag() == TypeTags.OBJECT_TYPE_TAG ||
                         type.getTag() == TypeTags.RECORD_TYPE_TAG ||
                         type.getTag() == TypeTags.INTERSECTION_TAG ||
-                        type.getTag() == TypeTags.INT_TAG;
+                        type.getTag() == TypeTags.INT_TAG ||
+                        type.getTag() == TypeTags.TUPLE_TAG;
             case Types.TINYINT:
             case Types.SMALLINT:
             case Types.INTEGER:


### PR DESCRIPTION
## Purpose
$subject

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1909

## Examples
```
time:Utc retrievedTimeUtc = check dbClient->queryRow(`
    SELECT timestamp_tz_type from DateTimeTypes where row_id = 1
`);
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests