### PR TITLE
Remove string usages from batchexecute and queryRow api

### DIFF
--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -39,7 +39,7 @@ public type Client client object {
     #                default column names/type of the query result set will be used
     # + return - Result in the type of `returnType`. If the `returnType` is not provided, the column names/type of
     #               the query are used
-    remote isolated function queryRow(string|ParameterizedQuery sqlQuery, typedesc<any> returnType = <>)
+    remote isolated function queryRow(ParameterizedQuery sqlQuery, typedesc<any> returnType = <>)
     returns returnType|Error;
 
     # Executes the provided DDL or DML SQL query and returns a summary of the execution.

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -60,7 +60,7 @@ public type Client client object {
     #            will return an `sql:BatchExecuteError`. However, the driver may or may not continue to process the
     #            remaining commands in the batch after a failure. The summary of the executed queries in case of an error
     #            can be accessed as `(<sql:BatchExecuteError> result).detail()?.executionResults`
-    remote isolated function batchExecute(string[]|ParameterizedQuery[] sqlQueries) returns ExecutionResult[]|Error;
+    remote isolated function batchExecute(ParameterizedQuery[] sqlQueries) returns ExecutionResult[]|Error;
 
     # Executes a SQL stored procedure and returns the result as stream and execution summary.
     #

--- a/ballerina/tests/batch-execute-query-test.bal
+++ b/ballerina/tests/batch-execute-query-test.bal
@@ -85,52 +85,7 @@ function batchInsertIntoDataTableFailure() {
 
 @test:Config {
     groups: ["batch-execute"],
-    dependsOn: [batchInsertIntoDataTableFailure]
-}
-function batchInsertIntoDataTable3() returns error? {
-    string[] sqlQueries =  [
-        "INSERT INTO DataTable (int_type, long_type, float_type) VALUES (10, 9223372036854774807, 123.34);",
-        "INSERT INTO DataTable (int_type, long_type, float_type) VALUES (11, 9223372036854774807, 123.34);"
-    ];
-    validateBatchExecutionResult(check batchExecuteQueryMockClient(sqlQueries), [1, 1], [-1, -1]);
-}
-
-@test:Config {
-    groups: ["batch-execute"],
-    dependsOn: [batchInsertIntoDataTable3]
-}
-function batchInsertIntoDataTable4() returns error? {
-    string[] sqlQueries =  [
-        "INSERT INTO DataTable (int_type, long_type, float_type) VALUES (12, 9223372036854774807, 123.34);",
-        "UPDATE DataTable SET int_type=13 WHERE int_type=13;"
-    ];
-    validateBatchExecutionResult(check batchExecuteQueryMockClient(sqlQueries), [1, 0], [-1, -1]);
-}
-
-@test:Config {
-    groups: ["batch-execute"],
-    dependsOn: [batchInsertIntoDataTable4]
-}
-function batchInsertIntoDataTableFailure2() returns error? {
-    string[] sqlQueries =  [
-        "INSERT INTO DataTable (int_type, long_type, float_type) VALUES (13, 9223372036854774807, 123.34);",
-        "UPDATE DataTable1 SET int_type=13 WHERE int_type=13;"
-    ];
-    ExecutionResult[]|error result = trap batchExecuteQueryMockClient(sqlQueries);
-    test:assertTrue(result is error);
-
-    if result is BatchExecuteError {
-        BatchExecuteErrorDetail errorDetails = result.detail();
-        test:assertEquals(errorDetails.executionResults.length(), 1);
-        test:assertEquals(errorDetails.executionResults[0].affectedRowCount, 1);
-    } else {
-        test:assertFail("BatchExecuteError expected.");
-    }
-}
-
-@test:Config {
-    groups: ["batch-execute"],
-    dependsOn: [batchInsertIntoDataTableFailure2]
+    dependsOn: [batchInsertIntoDataTable2]
 }
 function batchInsertIntoDataTableFailure3() {
     ParameterizedQuery[] sqlQueries = [
@@ -159,7 +114,7 @@ isolated function validateBatchExecutionResult(ExecutionResult[] results, int[] 
     }
 }
 
-function batchExecuteQueryMockClient(string[]|ParameterizedQuery[] sqlQueries)
+function batchExecuteQueryMockClient(ParameterizedQuery[] sqlQueries)
 returns ExecutionResult[]|error {
     MockClient dbClient = check new (url = batchExecuteDB, user = user, password = password);
     ExecutionResult[] result = check dbClient->batchExecute(sqlQueries);

--- a/ballerina/tests/client.bal
+++ b/ballerina/tests/client.bal
@@ -41,7 +41,7 @@ isolated client class MockClient {
         name: "nativeQuery"
     } external;
 
-    remote isolated function queryRow(string|ParameterizedQuery sqlQuery, typedesc<any> returnType = <>) 
+    remote isolated function queryRow(ParameterizedQuery sqlQuery, typedesc<any> returnType = <>)
     returns returnType|Error = @java:Method {
         'class: "io.ballerina.stdlib.sql.testutils.QueryTestUtils",
         name: "nativeQueryRow"

--- a/ballerina/tests/client.bal
+++ b/ballerina/tests/client.bal
@@ -53,7 +53,7 @@ isolated client class MockClient {
         name: "nativeExecute"
     } external;
 
-    remote isolated function batchExecute(string[]|ParameterizedQuery[] sqlQueries) returns ExecutionResult[]|Error {
+    remote isolated function batchExecute(ParameterizedQuery[] sqlQueries) returns ExecutionResult[]|Error {
         if (sqlQueries.length() == 0) {
             return error ApplicationError(" Parameter 'sqlQueries' cannot be empty array");
         }
@@ -87,7 +87,7 @@ returns Error? = @java:Method {
     'class: "io.ballerina.stdlib.sql.testutils.ClientTestUtils"
 } external;
 
-isolated function nativeBatchExecute(Client sqlClient, string[]|ParameterizedQuery[] sqlQueries)
+isolated function nativeBatchExecute(Client sqlClient, ParameterizedQuery[] sqlQueries)
 returns ExecutionResult[]|Error = @java:Method {
     'class: "io.ballerina.stdlib.sql.testutils.ExecuteTestUtils"
 } external;

--- a/ballerina/tests/query-row-test.bal
+++ b/ballerina/tests/query-row-test.bal
@@ -750,7 +750,7 @@ function queryRecordNoCheckNegative() returns error? {
 }
 function queryValue() returns error? {
     MockClient dbClient = check getMockClient(queryRowDb);
-    string sqlQuery = "SELECT COUNT(*) FROM DataTable";
+    ParameterizedQuery sqlQuery = `SELECT COUNT(*) FROM DataTable`;
     int count = check dbClient->queryRow(sqlQuery);
     check dbClient.close();
     test:assertEquals(count, 3);
@@ -795,7 +795,7 @@ function queryValueNegative2() returns error? {
 }
 function queryValueTypeInt() returns error? {
     MockClient dbClient = check getMockClient(queryRowDb);
-    string sqlQuery = "SELECT int_type FROM NumericTypes WHERE id = 1";
+    ParameterizedQuery sqlQuery = `SELECT int_type FROM NumericTypes WHERE id = 1`;
     int returnValue = check dbClient->queryRow(sqlQuery);
     check dbClient.close();
     test:assertEquals(returnValue, 2147483647);
@@ -806,7 +806,7 @@ function queryValueTypeInt() returns error? {
 }
 function queryValueTypeFloat() returns error? {
     MockClient dbClient = check getMockClient(queryRowDb);
-    string sqlQuery = "SELECT float_type FROM NumericTypes WHERE id = 1";
+    ParameterizedQuery sqlQuery = `SELECT float_type FROM NumericTypes WHERE id = 1`;
     float returnValue = check dbClient->queryRow(sqlQuery);
     check dbClient.close();
     test:assertEquals(returnValue, 1234.567);
@@ -817,7 +817,7 @@ function queryValueTypeFloat() returns error? {
 }
 function queryValueTypeDecimal() returns error? {
     MockClient dbClient = check getMockClient(queryRowDb);
-    string sqlQuery = "SELECT decimal_type FROM NumericTypes WHERE id = 1";
+    ParameterizedQuery sqlQuery = `SELECT decimal_type FROM NumericTypes WHERE id = 1`;
     decimal returnValue = check dbClient->queryRow(sqlQuery);
     check dbClient.close();
     decimal decimalValue = 1234.567;
@@ -829,7 +829,7 @@ function queryValueTypeDecimal() returns error? {
 }
 function queryValueTypeBigInt() returns error? {
     MockClient dbClient = check getMockClient(queryRowDb);
-    string sqlQuery = "SELECT bigint_type FROM NumericTypes WHERE id = 1";
+    ParameterizedQuery sqlQuery = `SELECT bigint_type FROM NumericTypes WHERE id = 1`;
     int returnValue = check dbClient->queryRow(sqlQuery);
     check dbClient.close();
     test:assertEquals(returnValue, 9223372036854774807);
@@ -840,7 +840,7 @@ function queryValueTypeBigInt() returns error? {
 }
 function queryValueTypeSmallInt() returns error? {
     MockClient dbClient = check getMockClient(queryRowDb);
-    string sqlQuery = "SELECT smallint_type FROM NumericTypes WHERE id = 1";
+    ParameterizedQuery sqlQuery = `SELECT smallint_type FROM NumericTypes WHERE id = 1`;
     int returnValue = check dbClient->queryRow(sqlQuery);
     check dbClient.close();
     test:assertEquals(returnValue, 32767);
@@ -851,7 +851,7 @@ function queryValueTypeSmallInt() returns error? {
 }
 function queryValueTypeTinyInt() returns error? {
     MockClient dbClient = check getMockClient(queryRowDb);
-    string sqlQuery = "SELECT tinyint_type FROM NumericTypes WHERE id = 1";
+    ParameterizedQuery sqlQuery = `SELECT tinyint_type FROM NumericTypes WHERE id = 1`;
     int returnValue = check dbClient->queryRow(sqlQuery);
     check dbClient.close();
     test:assertEquals(returnValue, 127);
@@ -862,7 +862,7 @@ function queryValueTypeTinyInt() returns error? {
 }
 function queryValueTypeBit() returns error? {
     MockClient dbClient = check getMockClient(queryRowDb);
-    string sqlQuery = "SELECT bit_type FROM NumericTypes WHERE id = 1";
+    ParameterizedQuery sqlQuery = `SELECT bit_type FROM NumericTypes WHERE id = 1`;
     int returnValue = check dbClient->queryRow(sqlQuery);
     check dbClient.close();
     test:assertEquals(returnValue, 1);
@@ -873,7 +873,7 @@ function queryValueTypeBit() returns error? {
 }
 function queryValueTypeNumeric() returns error? {
     MockClient dbClient = check getMockClient(queryRowDb);
-    string sqlQuery = "SELECT numeric_type FROM NumericTypes WHERE id = 1";
+    ParameterizedQuery sqlQuery = `SELECT numeric_type FROM NumericTypes WHERE id = 1`;
     decimal returnValue = check dbClient->queryRow(sqlQuery);
     check dbClient.close();
     decimal decimalValue = 1234.567;
@@ -885,7 +885,7 @@ function queryValueTypeNumeric() returns error? {
 }
 function queryValueTypeString() returns error? {
     MockClient dbClient = check getMockClient(queryRowDb);
-    string sqlQuery = "SELECT string_type FROM DataTable WHERE row_id = 1";
+    ParameterizedQuery sqlQuery = `SELECT string_type FROM DataTable WHERE row_id = 1`;
     string returnValue = check dbClient->queryRow(sqlQuery);
     check dbClient.close();
     test:assertEquals(returnValue, "Hello");
@@ -896,7 +896,7 @@ function queryValueTypeString() returns error? {
 }
 function queryValueTypeBoolean() returns error? {
     MockClient dbClient = check getMockClient(queryRowDb);
-    string sqlQuery = "SELECT boolean_type FROM DataTable WHERE row_id = 1";
+    ParameterizedQuery sqlQuery = `SELECT boolean_type FROM DataTable WHERE row_id = 1`;
     boolean returnValue = check dbClient->queryRow(sqlQuery);
     check dbClient.close();
     test:assertEquals(returnValue, true);
@@ -907,7 +907,7 @@ function queryValueTypeBoolean() returns error? {
 }
 function queryValueTypeBlob() returns error? {
     MockClient dbClient = check getMockClient(queryRowDb);
-    string sqlQuery = "SELECT blob_type FROM ComplexTypes WHERE row_id = 1";
+    ParameterizedQuery sqlQuery = `SELECT blob_type FROM ComplexTypes WHERE row_id = 1`;
     byte[] returnValue = check dbClient->queryRow(sqlQuery);
     check dbClient.close();
     test:assertEquals(returnValue, "wso2 ballerina blob test.".toBytes());
@@ -918,7 +918,7 @@ function queryValueTypeBlob() returns error? {
 }
 function queryValueTypeClob() returns error? {
     MockClient dbClient = check getMockClient(queryRowDb);
-    string sqlQuery = "SELECT clob_type FROM ComplexTypes WHERE row_id = 1";
+    ParameterizedQuery sqlQuery = `SELECT clob_type FROM ComplexTypes WHERE row_id = 1`;
     string returnValue = check dbClient->queryRow(sqlQuery);
     check dbClient.close();
     test:assertEquals(returnValue, "very long text");
@@ -929,7 +929,7 @@ function queryValueTypeClob() returns error? {
 }
 function queryValueTypeBinary() returns error? {
     MockClient dbClient = check getMockClient(queryRowDb);
-    string sqlQuery = "SELECT binary_type FROM ComplexTypes WHERE row_id = 1";
+    ParameterizedQuery sqlQuery = `SELECT binary_type FROM ComplexTypes WHERE row_id = 1`;
     byte[] returnValue = check dbClient->queryRow(sqlQuery);
     check dbClient.close();
     test:assertEquals(returnValue, "wso2 ballerina binary test.".toBytes());

--- a/ballerina/tests/utils.bal
+++ b/ballerina/tests/utils.bal
@@ -122,7 +122,7 @@ returns record {}|error? {
     return value;
 }
 
-function queryRecordMockClient(string url, string|ParameterizedQuery sqlQuery) 
+function queryRecordMockClient(string url, ParameterizedQuery sqlQuery)
 returns record {}|error {
     MockClient dbClient = check getMockClient(url);
     record {} resultRecord = check dbClient->queryRow(sqlQuery);

--- a/changelog.md
+++ b/changelog.md
@@ -19,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [Improve Errors](https://github.com/ballerina-platform/ballerina-standard-library/issues/1758)
-- [Improve the Batchupdate query to support string[]](https://github.com/ballerina-platform/ballerina-standard-library/issues/1529)
 - [Add completion type as nil in SQL query return stream type](https://github.com/ballerina-platform/ballerina-standard-library/issues/1654)
 - [Fix type cast error for query api containing database error](https://github.com/ballerina-platform/ballerina-standard-library/issues/1759)
 

--- a/native/src/main/java/io/ballerina/stdlib/sql/nativeimpl/ExecuteProcessor.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/nativeimpl/ExecuteProcessor.java
@@ -20,7 +20,6 @@ package io.ballerina.stdlib.sql.nativeimpl;
 
 import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.Future;
-import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.values.BArray;
@@ -181,151 +180,81 @@ public class ExecuteProcessor {
                 return ErrorGenerator.getSQLApplicationError("SQL Client is already closed, hence further operations" +
                         " are not allowed");
             }
-            if (paramSQLStrings.getElementType().getTag() == TypeTags.STRING_TAG) {
-                return batchExecuteMultipleQueries(client, sqlDatasource, paramSQLStrings, isWithinTrxBlock,
-                        trxResourceManager);
-            } else {
-                return batchExecuteParameterizedQuery(client, sqlDatasource, paramSQLStrings,
-                        statementParameterProcessor, isWithinTrxBlock, trxResourceManager);
+            Connection connection = null;
+            PreparedStatement statement = null;
+            ResultSet resultSet = null;
+            String sqlQuery = null;
+            List<BObject> parameters = new ArrayList<>();
+            List<BMap<BString, Object>> executionResults = new ArrayList<>();
+            try {
+                Object[] paramSQLObjects = paramSQLStrings.getValues();
+                BObject parameterizedQuery = (BObject) paramSQLObjects[0];
+                sqlQuery = getSqlQuery(parameterizedQuery);
+                parameters.add(parameterizedQuery);
+                for (int i = 1; i < paramSQLStrings.size(); i++) {
+                    parameterizedQuery = (BObject) paramSQLObjects[i];
+                    String paramSQLQuery = getSqlQuery(parameterizedQuery);
+
+                    if (sqlQuery.equals(paramSQLQuery)) {
+                        parameters.add(parameterizedQuery);
+                    } else {
+                        return ErrorGenerator.getSQLApplicationError("Batch Execute cannot contain different SQL " +
+                                "commands. These has to be executed in different function calls");
+                    }
+                }
+                connection = SQLDatasource.getConnection(isWithinTrxBlock, trxResourceManager, client, sqlDatasource);
+
+                if (sqlDatasource.getBatchExecuteGKFlag()) {
+                    statement = connection.prepareStatement(sqlQuery, Statement.RETURN_GENERATED_KEYS);
+                } else {
+                    statement = connection.prepareStatement(sqlQuery, Statement.NO_GENERATED_KEYS);
+                }
+
+                for (BObject param : parameters) {
+                    statementParameterProcessor.setParams(connection, statement, param);
+                    statement.addBatch();
+                }
+
+                int[] counts = statement.executeBatch();
+
+                if (sqlDatasource.getBatchExecuteGKFlag() && !isDdlStatement(sqlQuery)) {
+                    resultSet = statement.getGeneratedKeys();
+                }
+                for (int count : counts) {
+                    Map<String, Object> resultField = new HashMap<>();
+                    resultField.put(Constants.AFFECTED_ROW_COUNT_FIELD, count);
+                    Object lastInsertedId = null;
+                    if (resultSet != null && resultSet.next()) {
+                        lastInsertedId = getGeneratedKeys(resultSet);
+                    }
+                    resultField.put(Constants.LAST_INSERTED_ID_FIELD, lastInsertedId);
+                    executionResults.add(ValueCreator.createRecordValue(ModuleUtils.getModule(),
+                            Constants.EXECUTION_RESULT_RECORD, resultField));
+                }
+                return ValueCreator.createArrayValue(executionResults.toArray(), TypeCreator.createArrayType(
+                        TypeCreator.createRecordType(
+                                Constants.EXECUTION_RESULT_RECORD, ModuleUtils.getModule(), 0, false, 0)));
+            } catch (BatchUpdateException e) {
+                int[] updateCounts = e.getUpdateCounts();
+                for (int count : updateCounts) {
+                    Map<String, Object> resultField = new HashMap<>();
+                    resultField.put(Constants.AFFECTED_ROW_COUNT_FIELD, count);
+                    resultField.put(Constants.LAST_INSERTED_ID_FIELD, null);
+                    executionResults.add(ValueCreator.createRecordValue(ModuleUtils.getModule(),
+                            Constants.EXECUTION_RESULT_RECORD, resultField));
+                }
+                return ErrorGenerator.getSQLBatchExecuteError(e, executionResults,
+                        "Error while executing batch command starting with: '" + sqlQuery + "'.");
+            } catch (SQLException e) {
+                return ErrorGenerator.getSQLDatabaseError(e, "Error while executing SQL batch " +
+                        "command starting with : " + sqlQuery + ". ");
+            } catch (ApplicationError e) {
+                return ErrorGenerator.getSQLApplicationError(e);
+            } finally {
+                closeResources(isWithinTrxBlock, resultSet, statement, connection);
             }
         } else {
             return ErrorGenerator.getSQLApplicationError("Client is not properly initialized!");
-        }
-    }
-
-    private static Object batchExecuteParameterizedQuery(BObject client, SQLDatasource sqlDatasource,
-                                                         BArray paramSQLStrings,
-                                                         AbstractStatementParameterProcessor statementParamProcessor,
-                                                         boolean isWithinTrxBlock,
-                                                         TransactionResourceManager trxResourceManager) {
-        Connection connection = null;
-        PreparedStatement statement = null;
-        ResultSet resultSet = null;
-        String sqlQuery = null;
-        List<BObject> parameters = new ArrayList<>();
-        List<BMap<BString, Object>> executionResults = new ArrayList<>();
-        try {
-            Object[] paramSQLObjects = paramSQLStrings.getValues();
-            BObject parameterizedQuery = (BObject) paramSQLObjects[0];
-            sqlQuery = getSqlQuery(parameterizedQuery);
-            parameters.add(parameterizedQuery);
-            for (int i = 1; i < paramSQLStrings.size(); i++) {
-                parameterizedQuery = (BObject) paramSQLObjects[i];
-                String paramSQLQuery = getSqlQuery(parameterizedQuery);
-
-                if (sqlQuery.equals(paramSQLQuery)) {
-                    parameters.add(parameterizedQuery);
-                } else {
-                    return ErrorGenerator.getSQLApplicationError("Batch Execute cannot contain different SQL " +
-                            "commands. These has to be executed in different function calls");
-                }
-            }
-            connection = SQLDatasource.getConnection(isWithinTrxBlock, trxResourceManager, client, sqlDatasource);
-
-            if (sqlDatasource.getBatchExecuteGKFlag()) {
-                statement = connection.prepareStatement(sqlQuery, Statement.RETURN_GENERATED_KEYS);
-            } else {
-                statement = connection.prepareStatement(sqlQuery, Statement.NO_GENERATED_KEYS);
-            }
-
-            for (BObject param : parameters) {
-                statementParamProcessor.setParams(connection, statement, param);
-                statement.addBatch();
-            }
-
-            int[] counts = statement.executeBatch();
-
-            if (sqlDatasource.getBatchExecuteGKFlag() && !isDdlStatement(sqlQuery)) {
-                resultSet = statement.getGeneratedKeys();
-            }
-            for (int count : counts) {
-                Map<String, Object> resultField = new HashMap<>();
-                resultField.put(Constants.AFFECTED_ROW_COUNT_FIELD, count);
-                Object lastInsertedId = null;
-                if (resultSet != null && resultSet.next()) {
-                    lastInsertedId = getGeneratedKeys(resultSet);
-                }
-                resultField.put(Constants.LAST_INSERTED_ID_FIELD, lastInsertedId);
-                executionResults.add(ValueCreator.createRecordValue(ModuleUtils.getModule(),
-                        Constants.EXECUTION_RESULT_RECORD, resultField));
-            }
-            return ValueCreator.createArrayValue(executionResults.toArray(), TypeCreator.createArrayType(
-                    TypeCreator.createRecordType(
-                            Constants.EXECUTION_RESULT_RECORD, ModuleUtils.getModule(), 0, false, 0)));
-        } catch (BatchUpdateException e) {
-            int[] updateCounts = e.getUpdateCounts();
-            for (int count : updateCounts) {
-                Map<String, Object> resultField = new HashMap<>();
-                resultField.put(Constants.AFFECTED_ROW_COUNT_FIELD, count);
-                resultField.put(Constants.LAST_INSERTED_ID_FIELD, null);
-                executionResults.add(ValueCreator.createRecordValue(ModuleUtils.getModule(),
-                        Constants.EXECUTION_RESULT_RECORD, resultField));
-            }
-            return ErrorGenerator.getSQLBatchExecuteError(e, executionResults,
-                    "Error while executing batch command starting with: '" + sqlQuery + "'.");
-        } catch (SQLException e) {
-            return ErrorGenerator.getSQLDatabaseError(e, "Error while executing SQL batch " +
-                    "command starting with : " + sqlQuery + ". ");
-        } catch (ApplicationError e) {
-            return ErrorGenerator.getSQLApplicationError(e);
-        } finally {
-            closeResources(isWithinTrxBlock, resultSet, statement, connection);
-        }
-    }
-
-    private static Object batchExecuteMultipleQueries(BObject client, SQLDatasource sqlDatasource,
-                                                      BArray paramSQLStrings, boolean isWithinTrxBlock,
-                                                      TransactionResourceManager trxResourceManager) {
-        Connection connection = null;
-        Statement statement = null;
-        ResultSet resultSet = null;
-        String sqlQuery = null;
-        List<BMap<BString, Object>> executionResults = new ArrayList<>();
-        try {
-            String[] queries = paramSQLStrings.getStringArray();
-            sqlQuery = queries[0];
-
-            connection = SQLDatasource.getConnection(isWithinTrxBlock, trxResourceManager, client, sqlDatasource);
-            statement = connection.createStatement();
-
-            for (String query : queries) {
-                statement.addBatch(query);
-            }
-            int[] counts = statement.executeBatch();
-
-            if (sqlDatasource.getBatchExecuteGKFlag()) {
-                resultSet = statement.getGeneratedKeys();
-            }
-            for (int count : counts) {
-                Map<String, Object> resultField = new HashMap<>();
-                resultField.put(Constants.AFFECTED_ROW_COUNT_FIELD, count);
-                Object lastInsertedId = null;
-                if (resultSet != null && resultSet.next()) {
-                    lastInsertedId = getGeneratedKeys(resultSet);
-                }
-                resultField.put(Constants.LAST_INSERTED_ID_FIELD, lastInsertedId);
-                executionResults.add(ValueCreator.createRecordValue(ModuleUtils.getModule(),
-                        Constants.EXECUTION_RESULT_RECORD, resultField));
-            }
-            return ValueCreator.createArrayValue(executionResults.toArray(), TypeCreator.createArrayType(
-                    TypeCreator.createRecordType(
-                            Constants.EXECUTION_RESULT_RECORD, ModuleUtils.getModule(), 0, false, 0)));
-        } catch (BatchUpdateException e) {
-            int[] updateCounts = e.getUpdateCounts();
-            for (int count : updateCounts) {
-                Map<String, Object> resultField = new HashMap<>();
-                resultField.put(Constants.AFFECTED_ROW_COUNT_FIELD, count);
-                resultField.put(Constants.LAST_INSERTED_ID_FIELD, null);
-                executionResults.add(ValueCreator.createRecordValue(ModuleUtils.getModule(),
-                        Constants.EXECUTION_RESULT_RECORD, resultField));
-            }
-            return ErrorGenerator.getSQLBatchExecuteError(e, executionResults,
-                    "Error while executing batch command starting with: '" + sqlQuery + "'.");
-        } catch (SQLException e) {
-            return ErrorGenerator.getSQLDatabaseError(e, "Error while executing SQL batch " +
-                    "command starting with : " + sqlQuery + ". ");
-        } finally {
-            closeResources(isWithinTrxBlock, resultSet, statement, connection);
         }
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/sql/nativeimpl/QueryProcessor.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/nativeimpl/QueryProcessor.java
@@ -148,7 +148,7 @@ public class QueryProcessor {
         }
     }
 
-    public static Object nativeQueryRow(Environment env, BObject client, Object paramSQLString,
+    public static Object nativeQueryRow(Environment env, BObject client, BObject paramSQLString,
             BTypedesc ballerinaType, AbstractStatementParameterProcessor statementParameterProcessor,
             AbstractResultParameterProcessor resultParameterProcessor) {
         TransactionResourceManager trxResourceManager = TransactionResourceManager.getInstance();
@@ -168,7 +168,7 @@ public class QueryProcessor {
     }
 
     private static Object nativeQueryRowExecutable(
-            BObject client, Object paramSQLString,
+            BObject client, BObject paramSQLString,
             BTypedesc ballerinaType,
             AbstractStatementParameterProcessor statementParameterProcessor,
             AbstractResultParameterProcessor resultParameterProcessor, boolean isWithInTrxBlock,
@@ -190,16 +190,10 @@ public class QueryProcessor {
             ResultSet resultSet = null;
             String sqlQuery = null;
             try {
-                if (paramSQLString instanceof BString) {
-                    sqlQuery = ((BString) paramSQLString).getValue();
-                } else {
-                    sqlQuery = Utils.getSqlQuery((BObject) paramSQLString);
-                }
+                sqlQuery = Utils.getSqlQuery(paramSQLString);
                 connection = SQLDatasource.getConnection(isWithInTrxBlock, trxResourceManager, client, sqlDatasource);
                 statement = connection.prepareStatement(sqlQuery);
-                if (paramSQLString instanceof BObject) {
-                    statementParameterProcessor.setParams(connection, statement, (BObject) paramSQLString);
-                }
+                statementParameterProcessor.setParams(connection, statement, paramSQLString);
                 resultSet = statement.executeQuery();
                 if (!resultSet.next()) {
                     return ErrorGenerator.getNoRowsError("Query did not retrieve any rows.");

--- a/test-utils/src/main/java/io/ballerina/stdlib/sql/testutils/QueryTestUtils.java
+++ b/test-utils/src/main/java/io/ballerina/stdlib/sql/testutils/QueryTestUtils.java
@@ -44,7 +44,7 @@ public class QueryTestUtils {
                 resultParametersProcessor);
     }
 
-    public static Object nativeQueryRow(Environment env, BObject client, Object paramSQLString, BTypedesc recordType) {
+    public static Object nativeQueryRow(Environment env, BObject client, BObject paramSQLString, BTypedesc recordType) {
         DefaultStatementParameterProcessor statementParametersProcessor = DefaultStatementParameterProcessor
                 .getInstance();
         DefaultResultParameterProcessor resultParametersProcessor = DefaultResultParameterProcessor


### PR DESCRIPTION
## Purpose
$subject part of https://github.com/ballerina-platform/ballerina-standard-library/issues/1880

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [ ] Added tests