### PR TITLE
Add support for union types in queryRow API

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [Accept escaped backtick as insertions in parameterised query](https://github.com/ballerina-platform/ballerina-standard-library/issues/2056)
+- [Add support for handling union types in queryRow()](https://github.com/ballerina-platform/ballerina-standard-library/issues/2333)
 
 
 ## [1.0.0] - 2021-10-09

--- a/native/src/main/java/io/ballerina/stdlib/sql/nativeimpl/QueryProcessor.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/nativeimpl/QueryProcessor.java
@@ -195,11 +195,11 @@ public class QueryProcessor {
                 }
 
                 if (describingType.getTag() == TypeTags.UNION_TAG) {
-                    return getUnionType((UnionType) describingType, resultSet, resultParameterProcessor);
+                    return getUnionTypeBValue((UnionType) describingType, resultSet, resultParameterProcessor);
                 }
 
                 // Return-type is either a record or a primitive
-                return getRecordOrPrimitiveType(describingType, resultSet, resultParameterProcessor);
+                return getRecordOrPrimitiveTypeBValue(describingType, resultSet, resultParameterProcessor);
             } catch (SQLException e) {
                 return ErrorGenerator.getSQLDatabaseError(e,
                         String.format("Error while executing SQL query: %s. ", sqlQuery));
@@ -219,16 +219,16 @@ public class QueryProcessor {
         return ErrorGenerator.getSQLApplicationError("Client is not properly initialized!");
     }
 
-    private static Object getUnionType(
+    private static Object getUnionTypeBValue(
             UnionType describingType, ResultSet resultSet, AbstractResultParameterProcessor resultParameterProcessor)
             throws SQLException, TypeMismatchError {
         for (Type type: describingType.getMemberTypes()) {
             try {
                 // If one of the types inside the union is a union, recursively check
                 if (type.getTag() == TypeTags.UNION_TAG) {
-                    return getUnionType(describingType, resultSet, resultParameterProcessor);
+                    return getUnionTypeBValue(describingType, resultSet, resultParameterProcessor);
                 }
-                return getRecordOrPrimitiveType(type, resultSet, resultParameterProcessor);
+                return getRecordOrPrimitiveTypeBValue(type, resultSet, resultParameterProcessor);
             } catch (ApplicationError e) {
                 // Ignored
             }
@@ -239,7 +239,7 @@ public class QueryProcessor {
                 "The result generated from the query cannot be mapped to type %s.", describingType));
     }
 
-    private static Object getRecordOrPrimitiveType(
+    private static Object getRecordOrPrimitiveTypeBValue(
             Type type, ResultSet resultSet, AbstractResultParameterProcessor resultParameterProcessor)
             throws SQLException, ApplicationError {
         if (type.getTag() == TypeTags.RECORD_TYPE_TAG && !Utils.isSupportedRecordType(type)) {

--- a/native/src/main/java/io/ballerina/stdlib/sql/nativeimpl/QueryProcessor.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/nativeimpl/QueryProcessor.java
@@ -219,6 +219,8 @@ public class QueryProcessor {
         return ErrorGenerator.getSQLApplicationError("Client is not properly initialized!");
     }
 
+    // This method iterates through each type in the union type and checks whether it is compatible with the result
+    // from the query.
     private static Object getUnionTypeBValue(
             UnionType describingType, ResultSet resultSet, AbstractResultParameterProcessor resultParameterProcessor)
             throws SQLException, TypeMismatchError {
@@ -228,9 +230,13 @@ public class QueryProcessor {
                 if (type.getTag() == TypeTags.UNION_TAG) {
                     return getUnionTypeBValue(describingType, resultSet, resultParameterProcessor);
                 }
+
+                // Attempt to convert the query result to the current type
                 return getRecordOrPrimitiveTypeBValue(type, resultSet, resultParameterProcessor);
             } catch (ApplicationError e) {
                 // Ignored
+                // If an ApplicationError is thrown, the type is not compatible with the query result. Hence, it is
+                // ignored and the next type conversion is attempted.
             }
         }
 

--- a/native/src/main/java/io/ballerina/stdlib/sql/nativeimpl/QueryProcessor.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/nativeimpl/QueryProcessor.java
@@ -26,6 +26,7 @@ import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.RecordType;
 import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.types.UnionType;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BStream;
@@ -35,6 +36,7 @@ import io.ballerina.stdlib.sql.Constants;
 import io.ballerina.stdlib.sql.ParameterizedQuery;
 import io.ballerina.stdlib.sql.datasource.SQLDatasource;
 import io.ballerina.stdlib.sql.exception.ApplicationError;
+import io.ballerina.stdlib.sql.exception.TypeMismatchError;
 import io.ballerina.stdlib.sql.parameterprocessor.AbstractResultParameterProcessor;
 import io.ballerina.stdlib.sql.parameterprocessor.AbstractStatementParameterProcessor;
 import io.ballerina.stdlib.sql.utils.ColumnDefinition;
@@ -170,10 +172,6 @@ public class QueryProcessor {
             AbstractResultParameterProcessor resultParameterProcessor, boolean isWithInTrxBlock,
             TransactionResourceManager trxResourceManager) {
         Type describingType = ballerinaType.getDescribingType();
-        if (describingType.getTag() == TypeTags.UNION_TAG) {
-            return ErrorGenerator.getSQLApplicationError("Return type cannot be a union of multiple types.");
-        }
-
         Object dbClient = client.getNativeData(Constants.DATABASE_CLIENT);
         if (dbClient != null) {
             SQLDatasource sqlDatasource = (SQLDatasource) dbClient;
@@ -196,19 +194,12 @@ public class QueryProcessor {
                     return ErrorGenerator.getNoRowsError("Query did not retrieve any rows.");
                 }
 
-                if (describingType.getTag() == TypeTags.RECORD_TYPE_TAG &&
-                        !Utils.isSupportedRecordType(describingType)) {
-                    RecordType recordConstraint = (RecordType) describingType;
-                    List<ColumnDefinition> columnDefinitions = Utils.getColumnDefinitions(resultSet, recordConstraint);
-                    return resultParameterProcessor.createRecord(resultSet, columnDefinitions, recordConstraint);
-                } else {
-                    if (resultSet.getMetaData().getColumnCount() > 1) {
-                        return ErrorGenerator.getTypeMismatchError(
-                                String.format("Expected type to be '%s' but found 'record{}'.", describingType));
-                    }
-                    PrimitiveTypeColumnDefinition definition = Utils.getColumnDefinition(resultSet, 1, describingType);
-                    return resultParameterProcessor.createValue(resultSet, 1, definition);
+                if (describingType.getTag() == TypeTags.UNION_TAG) {
+                    return getUnionType((UnionType) describingType, resultSet, resultParameterProcessor);
                 }
+
+                // Return-type is either a record or a primitive
+                return getRecordOrPrimitiveType(describingType, resultSet, resultParameterProcessor);
             } catch (SQLException e) {
                 return ErrorGenerator.getSQLDatabaseError(e,
                         String.format("Error while executing SQL query: %s. ", sqlQuery));
@@ -226,6 +217,43 @@ public class QueryProcessor {
             }
         }
         return ErrorGenerator.getSQLApplicationError("Client is not properly initialized!");
+    }
+
+    private static Object getUnionType(
+            UnionType describingType, ResultSet resultSet, AbstractResultParameterProcessor resultParameterProcessor)
+            throws SQLException, TypeMismatchError {
+        for (Type type: describingType.getMemberTypes()) {
+            try {
+                // If one of the types inside the union is a union, recursively check
+                if (type.getTag() == TypeTags.UNION_TAG) {
+                    return getUnionType(describingType, resultSet, resultParameterProcessor);
+                }
+                return getRecordOrPrimitiveType(type, resultSet, resultParameterProcessor);
+            } catch (ApplicationError e) {
+                // Ignored
+            }
+        }
+
+        // No valid mapping was found in the union-type
+        throw new TypeMismatchError(String.format(
+                "The result generated from the query cannot be mapped to type %s.", describingType));
+    }
+
+    private static Object getRecordOrPrimitiveType(
+            Type type, ResultSet resultSet, AbstractResultParameterProcessor resultParameterProcessor)
+            throws SQLException, ApplicationError {
+        if (type.getTag() == TypeTags.RECORD_TYPE_TAG && !Utils.isSupportedRecordType(type)) {
+            RecordType recordConstraint = (RecordType) type;
+            List<ColumnDefinition> columnDefinitions = Utils.getColumnDefinitions(resultSet, recordConstraint);
+            return resultParameterProcessor.createRecord(resultSet, columnDefinitions, recordConstraint);
+        }
+
+        if (resultSet.getMetaData().getColumnCount() > 1) {
+            throw new TypeMismatchError(String.format("Expected type to be '%s' but found 'record{}'.", type));
+        }
+
+        PrimitiveTypeColumnDefinition definition = Utils.getColumnDefinition(resultSet, 1, type);
+        return resultParameterProcessor.createValue(resultSet, 1, definition);
     }
 
     private static BStream getErrorStream(Object recordType, BError errorValue) {


### PR DESCRIPTION
## Purpose
$subject

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/2333

## Examples
`record {}|int count = check dbClient->queryRow(sqlQuery);`

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests