### PR TITLE
Change queryRow() API accept anydata as the return-type instead of any

### DIFF
--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -36,7 +36,7 @@ public type Client client object {
     # + returnType - The `typedesc` of the record/type that should be returned as a result. If this is not provided, the
     #                default column names/type of the query result set will be used
     # + return - Result in the `returnType` type
-    remote isolated function queryRow(ParameterizedQuery sqlQuery, typedesc<any> returnType = <>)
+    remote isolated function queryRow(ParameterizedQuery sqlQuery, typedesc<anydata> returnType = <>)
     returns returnType|Error;
 
     # Executes the provided DDL or DML SQL query and returns a summary of the execution.

--- a/ballerina/tests/client.bal
+++ b/ballerina/tests/client.bal
@@ -41,7 +41,7 @@ isolated client class MockClient {
         name: "nativeQuery"
     } external;
 
-    remote isolated function queryRow(ParameterizedQuery sqlQuery, typedesc<any> returnType = <>) 
+    remote isolated function queryRow(ParameterizedQuery sqlQuery, typedesc<anydata> returnType = <>)
     returns returnType|Error = @java:Method {
         'class: "io.ballerina.stdlib.sql.testutils.QueryTestUtils",
         name: "nativeQueryRow"

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Accept escaped backtick as insertions in parameterised query](https://github.com/ballerina-platform/ballerina-standard-library/issues/2056)
 - [Add support for handling union types in queryRow()](https://github.com/ballerina-platform/ballerina-standard-library/issues/2333)
 - [Validate connection pool configurations](https://github.com/ballerina-platform/ballerina-standard-library/issues/2355)
+- [Change queryRow return type to anydata](https://github.com/ballerina-platform/ballerina-standard-library/issues/2390)
 
 ## [1.0.0] - 2021-10-09
 


### PR DESCRIPTION
## Purpose

Related issue: https://github.com/ballerina-platform/ballerina-standard-library/issues/2390

## Related PRs
https://github.com/ballerina-platform/module-ballerinax-mssql/pull/93
https://github.com/ballerina-platform/module-ballerinax-java.jdbc/pull/291
https://github.com/ballerina-platform/module-ballerinax-oracledb/pull/72
https://github.com/ballerina-platform/module-ballerinax-mysql/pull/291
https://github.com/ballerina-platform/module-ballerinax-mssql/pull/93

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests