### PR TITLE
Fix sql:queryConcat not working for empty query

### DIFF
--- a/ballerina/tests/simple-params-query-test.bal
+++ b/ballerina/tests/simple-params-query-test.bal
@@ -804,7 +804,8 @@ function testInOperator2() returns error? {
 }
 function testInOperator3() returns error? {
     int[] ids = [1, 2, 3];
-    ParameterizedQuery sqlQuery = `SELECT count(*) as total FROM DataTable WHERE row_id in (${ids[0]}, ${ids[1]}, ${ids[2]})`;
+    ParameterizedQuery sqlQuery = queryConcat(
+                       `SELECT count(*) as total FROM DataTable WHERE row_id in (${ids[0]}, ${ids[1]}, ${ids[2]})`, ``);
     record {}? returnData = check queryMockClient(simpleParamsDb, sqlQuery);
     test:assertEquals(returnData["TOTAL"], 3, "Total count is different.");
 }
@@ -814,7 +815,7 @@ function testInOperator3() returns error? {
 }
 function testInOperator4() returns error? {
     int[] ids = [1, 2, 3];
-    ParameterizedQuery sqlQuery = queryConcat(`SELECT count(*) as total FROM DataTable WHERE row_id IN (`, arrayFlattenQuery(ids), `)`);
+    ParameterizedQuery sqlQuery = queryConcat(``, `SELECT count(*) as total FROM DataTable WHERE row_id IN (`, arrayFlattenQuery(ids), `)`);
     record {}? returnData = check queryMockClient(simpleParamsDb, sqlQuery);
     test:assertEquals(returnData["TOTAL"], 3, "Total count is different.");
 }

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -35,15 +35,17 @@ isolated function prepareParameterizedQuery(ParameterizedQuery[] queries) return
     string previousString = "";
     foreach ParameterizedQuery query in queries {
         int length = query.strings.length();
-        previousString = previousString + query.strings[0];
-        if length > 1 {
-            newQueryStrings.push(previousString);
-            foreach var i in 1 ... length - 2 {
-                newQueryStrings.push(query.strings[i]);
+        if length > 0 {
+            previousString = previousString + query.strings[0];
+            if length > 1 {
+                newQueryStrings.push(previousString);
+                foreach var i in 1 ... length - 2 {
+                    newQueryStrings.push(query.strings[i]);
+                }
+                previousString = query.strings[length - 1];
             }
-            previousString = query.strings[length - 1];
+            addValues(query.insertions, newQueryInsertions);
         }
-        addValues(query.insertions, newQueryInsertions);
     }
     newQueryStrings.push(previousString);
     newParameterizedQuery.insertions = newQueryInsertions;

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Added support for metadata retrieval](https://github.com/ballerina-platform/ballerina-standard-library/issues/3061)
 
 ### Changed
+- [Fix sql:queryConcat not working for empty query](https://github.com/ballerina-platform/ballerina-standard-library/issues/3127)
 
 ## [1.4.1] - 2022-06-21
 


### PR DESCRIPTION
## Purpose
$subject 

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/3127

## Examples
N/A

## Checklist
- [x] Linked to an issue
- [ ] ~Updated the specification~
- [x] Updated the changelog
- [x] Added tests
