### PR TITLE
Defer vulnerability till october end

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+#HSSQLDB Driver defer this month as the fixed version is not released yet
+CVE-2022-41853 exp:2022-11-01


### PR DESCRIPTION
## Purpose
$subject since the fixed version 2.7.1 is not released yet and no released date announced (https://hsqldb.org)

Since this dependency is used only for testing purposes this is a false positive.

Fixes:

## Examples

## Checklist
- [ ] ~Linked to an issue~
- [ ] ~Updated the specification~
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
- [ ] ~Checked native-image compatibility~
