### PR TITLE
Fix Unable to set unlimited life time (0) to ballerina.sql.maxConnectionLifeTime

### DIFF
--- a/ballerina/connection-pool.bal
+++ b/ballerina/connection-pool.bal
@@ -27,9 +27,9 @@ configurable int minIdleConnections = 15;
 #                        Includes both idle and in-use connections. The default value is 15. This can be changed through
 #                        the configuration API with the `ballerina.sql.maxOpenConnections` key
 # + maxConnectionLifeTime - The maximum lifetime (in seconds) of a connection in the pool. The default value is 1800
-#                           seconds (30 minutes). This can be changed through the configuration API with the
-#                           `ballerina.sql.maxConnectionLifeTime` key. A value of 0 indicates an unlimited maximum
-#                           lifetime (infinite lifetime)
+#                           seconds (30 minutes). A value of 0 indicates an unlimited maximum lifetime (infinite lifetime).
+#                           The minimum allowed value is 30 seconds. This can be changed through the configuration API
+#                           with the `ballerina.sql.maxConnectionLifeTime` key.
 # + minIdleConnections - The minimum number of idle connections that the pool tries to maintain. The default value
 #                        is the same as `maxOpenConnections` and it can be changed through the configuration
 #                        API with the `ballerina.sql.minIdleConnections` key

--- a/ballerina/tests/connection-init-test.bal
+++ b/ballerina/tests/connection-init-test.bal
@@ -258,7 +258,8 @@ function testWithConnectionPoolNegative() returns error? {
     };
     err = new (url = connectDB, user = user, password = password, connectionPool = connectionPool);
     if err is error {
-        test:assertEquals(err.message(), "Error in SQL connector configuration: ConnectionPool field 'maxConnectionLifeTime' cannot be less than 30s.");
+        test:assertEquals(err.message(), "Error in SQL connector configuration: ConnectionPool field " +
+                                         "'maxConnectionLifeTime' can either be 0 or greater than or equal to 30.");
     } else {
         test:assertFail("Connection should fail with negative value");
     }

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - [Updated API Docs](https://github.com/ballerina-platform/ballerina-standard-library/issues/3463)
+- [Fix Unable to set unlimited life time (0) to ballerina.sql.maxConnectionLifeTime](https://github.com/ballerina-platform/ballerina-standard-library/issues/3657)
 
 ## [1.5.0] - 2022-09-08
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - [Updated API Docs](https://github.com/ballerina-platform/ballerina-standard-library/issues/3463)
-- [Fix Unable to set unlimited life time (0) to ballerina.sql.maxConnectionLifeTime](https://github.com/ballerina-platform/ballerina-standard-library/issues/3657)
+- [Fix unable to set unlimited lifetime (0) to ballerina.sql.maxConnectionLifeTime](https://github.com/ballerina-platform/ballerina-standard-library/issues/3657)
 
 ## [1.5.0] - 2022-09-08
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/sql/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/sql/compiler/CompilerPluginTest.java
@@ -69,27 +69,27 @@ public class CompilerPluginTest {
                 .collect(Collectors.toList());
         long availableErrors = errorDiagnosticsList.size();
 
-        Assert.assertEquals(availableErrors, 4);
+        Assert.assertEquals(availableErrors, 5);
 
         DiagnosticInfo maxOpenConnectionZero = errorDiagnosticsList.get(0).diagnosticInfo();
         Assert.assertEquals(maxOpenConnectionZero.code(), SQLDiagnosticsCodes.SQL_101.getCode());
-        Assert.assertEquals(maxOpenConnectionZero.messageFormat(),
-                "invalid value: expected value is greater than one");
+        Assert.assertEquals(maxOpenConnectionZero.messageFormat(), SQLDiagnosticsCodes.SQL_101.getMessage());
 
         DiagnosticInfo maxConnectionLifeTime = errorDiagnosticsList.get(1).diagnosticInfo();
         Assert.assertEquals(maxConnectionLifeTime.code(), SQLDiagnosticsCodes.SQL_103.getCode());
-        Assert.assertEquals(maxConnectionLifeTime.messageFormat(),
-                "invalid value: expected value is greater than or equal to 30");
+        Assert.assertEquals(maxConnectionLifeTime.messageFormat(), SQLDiagnosticsCodes.SQL_103.getMessage());
 
         DiagnosticInfo minIdleConnections = errorDiagnosticsList.get(2).diagnosticInfo();
         Assert.assertEquals(minIdleConnections.code(), SQLDiagnosticsCodes.SQL_102.getCode());
-        Assert.assertEquals(minIdleConnections.messageFormat(),
-                "invalid value: expected value is greater than zero");
+        Assert.assertEquals(minIdleConnections.messageFormat(), SQLDiagnosticsCodes.SQL_102.getMessage());
 
         DiagnosticInfo maxOpenConnectionNegative = errorDiagnosticsList.get(3).diagnosticInfo();
         Assert.assertEquals(maxOpenConnectionNegative.code(), SQLDiagnosticsCodes.SQL_101.getCode());
-        Assert.assertEquals(maxOpenConnectionNegative.messageFormat(),
-                "invalid value: expected value is greater than one");
+        Assert.assertEquals(maxOpenConnectionNegative.messageFormat(), SQLDiagnosticsCodes.SQL_101.getMessage());
+
+        DiagnosticInfo maxConnectionLifeTimeNegative = errorDiagnosticsList.get(4).diagnosticInfo();
+        Assert.assertEquals(maxConnectionLifeTimeNegative.code(), SQLDiagnosticsCodes.SQL_103.getCode());
+        Assert.assertEquals(maxConnectionLifeTimeNegative.messageFormat(), SQLDiagnosticsCodes.SQL_103.getMessage());
     }
 
     @Test

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample1/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample1/main.bal
@@ -44,7 +44,15 @@ public function main() {
         minIdleConnections: 0
     };
 
-    ConnectionPool pool5 = {
+    sql:ConnectionPool pool5 = {
+        maxConnectionLifeTime: 0
+    };
+
+    ConnectionPool pool6 = {
         connection: 0
+    };
+
+    sql:ConnectionPool pool7 = {
+        maxConnectionLifeTime: -5
     };
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/sql/compiler/SQLDiagnosticsCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/sql/compiler/SQLDiagnosticsCodes.java
@@ -28,7 +28,7 @@ import static io.ballerina.tools.diagnostics.DiagnosticSeverity.HINT;
 public enum SQLDiagnosticsCodes {
     SQL_101("SQL_101", "invalid value: expected value is greater than one", ERROR),
     SQL_102("SQL_102", "invalid value: expected value is greater than zero", ERROR),
-    SQL_103("SQL_103", "invalid value: expected value is greater than or equal to 30", ERROR),
+    SQL_103("SQL_103", "invalid value: expected value is either 0 or greater than or equal to 30", ERROR),
 
     // Out parameter return type validations diagnostics
     SQL_201("SQL_201", "invalid value: expected value is array", ERROR),

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/sql/compiler/analyzer/ConnectionPoolConfigAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/sql/compiler/analyzer/ConnectionPoolConfigAnalyzer.java
@@ -121,7 +121,7 @@ public class ConnectionPoolConfigAnalyzer implements AnalysisTask<SyntaxNodeAnal
                         break;
                     case Constants.ConnectionPool.MAX_CONNECTION_LIFE_TIME:
                         float maxConnectionTime = Float.parseFloat(getTerminalNodeValue(valueNode, "30"));
-                        if (maxConnectionTime < 30) {
+                        if (maxConnectionTime < 0 || (maxConnectionTime > 0 && maxConnectionTime < 30)) {
                             DiagnosticInfo diagnosticInfo = new DiagnosticInfo(SQL_103.getCode(), SQL_103.getMessage(),
                                     SQL_103.getSeverity());
                             ctx.reportDiagnostic(

--- a/native/src/main/java/io/ballerina/stdlib/sql/datasource/SQLDatasource.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/datasource/SQLDatasource.java
@@ -328,13 +328,13 @@ public class SQLDatasource {
 
                 Object connLifeTimeSec = sqlDatasourceParams.connectionPool
                         .get(Constants.ConnectionPool.MAX_CONNECTION_LIFE_TIME);
-                BDecimal connLifeTime = (BDecimal) connLifeTimeSec;
-                if (connLifeTime.floatValue() < 30) {
+                double connLifeTime = ((BDecimal) connLifeTimeSec).floatValue();
+                if (connLifeTime < 0 || (connLifeTime > 0 && connLifeTime < 30)) {
                     // Here if the connection life time is minimum 30s, the default value will be used
-                    throw new ApplicationError(
-                            "ConnectionPool field 'maxConnectionLifeTime' cannot be less than 30s.");
+                    throw new ApplicationError("ConnectionPool field 'maxConnectionLifeTime' can either be 0 " +
+                            "or greater than or equal to 30.");
                 }
-                long connLifeTimeMS = Double.valueOf(connLifeTime.floatValue() * 1000).longValue();
+                long connLifeTimeMS = Double.valueOf(connLifeTime * 1000).longValue();
                 config.setMaxLifetime(connLifeTimeMS);
 
                 int minIdleConnections = sqlDatasourceParams.connectionPool


### PR DESCRIPTION
## Purpose
$subject

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/3657

## Examples

## Checklist
- [x] Linked to an issue
- [ ] ~Updated the specification~
- [x] Updated the changelog
- [x] Added tests
- [x] Checked native-image compatibility
