### PR TITLE
Moving CheckConstraints to table level

### DIFF
--- a/ballerina/metadata_types.bal
+++ b/ballerina/metadata_types.bal
@@ -63,10 +63,12 @@ public enum ParameterMode {
 # + name - The name of the table
 # + 'type - Whether the table is a base table or a view
 # + columns - The columns included in the table
+# + checkConstraints - Check constraints associated with the column
 public type TableDefinition record {
     string name;
     TableType 'type;
     ColumnDefinition[] columns?;
+    CheckConstraint[] checkConstraints?;
 };
 
 # Represents a column in a table.
@@ -76,14 +78,12 @@ public type TableDefinition record {
 # + defaultValue - The default value of the column
 # + nullable - Whether the column is nullable
 # + referentialConstraints - Referential constraints (foreign key relationships) associated with the column
-# + checkConstraints - Check constraints associated with the column
 public type ColumnDefinition record {
     string name;
     string 'type;
     anydata? defaultValue;
     boolean nullable;
     ReferentialConstraint[] referentialConstraints?;
-    CheckConstraint[] checkConstraints?;
 };
 
 # Represents a referential constraint (foriegn key constraint).

--- a/ballerina/metadata_types.bal
+++ b/ballerina/metadata_types.bal
@@ -63,7 +63,7 @@ public enum ParameterMode {
 # + name - The name of the table
 # + 'type - Whether the table is a base table or a view
 # + columns - The columns included in the table
-# + checkConstraints - Check constraints associated with the column
+# + checkConstraints - Check constraints associated with the table
 public type TableDefinition record {
     string name;
     TableType 'type;

--- a/ballerina/tests/metadata-test.bal
+++ b/ballerina/tests/metadata-test.bal
@@ -134,13 +134,7 @@ function getTableInfoWithConstraintsTest() returns error? {
                 "name":"PERSONID",
                 "type":"INTEGER",
                 "defaultValue":null,
-                "nullable":false,
-                "checkConstraints": [
-                    {
-                        "name":"SYS_CT_10125",
-                        "clause":"PUBLIC.PERSON.PERSONID>100"
-                    }
-                ]
+                "nullable":false
             },
             {
                 "name":"NAME",
@@ -161,13 +155,17 @@ function getTableInfoWithConstraintsTest() returns error? {
                         "updateRule":NO_ACTION,
                         "deleteRule":NO_ACTION
                     }
-                ],
-                "checkConstraints": [
-                    {
-                        "name":"SYS_CT_10126",
-                        "clause":"PUBLIC.PERSON.COMPANYID>20"
-                    }
                 ]
+            }
+        ],
+        "checkConstraints": [
+            {
+                "name":"SYS_CT_10125",
+                "clause":"PUBLIC.PERSON.PERSONID>100"
+            },
+            {
+                "name":"SYS_CT_10126",
+                "clause":"PUBLIC.PERSON.COMPANYID>20"
             }
         ]
     });
@@ -188,13 +186,7 @@ function getTableInfoWithConstraintsTest2() returns error? {
                 "name":"PERSONID",
                 "type":"INTEGER",
                 "defaultValue":null,
-                "nullable":false,
-                "checkConstraints": [
-                    {
-                        "name":"SYS_CT_10140",
-                        "clause":"PUBLIC.PERSON2.PERSONID>100"
-                    }
-                ]
+                "nullable":false
             },
             {
                 "name":"NAME",
@@ -215,13 +207,17 @@ function getTableInfoWithConstraintsTest2() returns error? {
                         "updateRule":CASCADE,
                         "deleteRule":CASCADE
                     }
-                ],
-                "checkConstraints": [
-                    {
-                        "name":"SYS_CT_10141",
-                        "clause":"PUBLIC.PERSON2.COMPANYID>20"
-                    }
                 ]
+            }
+        ],
+        "checkConstraints": [
+            {
+                "name":"SYS_CT_10140",
+                "clause":"PUBLIC.PERSON2.PERSONID>100"
+            },
+            {
+                "name":"SYS_CT_10141",
+                "clause":"PUBLIC.PERSON2.COMPANYID>20"
             }
         ]
     });

--- a/ballerina/tests/schema_client.bal
+++ b/ballerina/tests/schema_client.bal
@@ -192,13 +192,15 @@ isolated client class MockSchemaClient {
     private isolated function getCheckConstraints(string tableName) returns CheckConstraint[]|Error {
         CheckConstraint[] checkConstraints = [];
         stream<record {}, error?> checkConstraintStream = self.dbClient->query(`
-            SELECT DISTINCT 
+            SELECT 
                 CC.CONSTRAINT_NAME AS CONSTRAINT_NAME,
-                CC.CHECK_CLAUSE AS CHECK_CLAUSE 
-            FROM INFORMATION_SCHEMA.CHECK_CONSTRAINTS AS CC 
-            JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS TC 
-            ON CC.CONSTRAINT_SCHEMA = TC.CONSTRAINT_SCHEMA 
-            WHERE CC.CONSTRAINT_SCHEMA=${self.database} AND TC.TABLE_NAME=${tableName};
+                CC.CHECK_CLAUSE AS CHECK_CLAUSE
+            FROM INFORMATION_SCHEMA.CHECK_CONSTRAINTS CC
+            JOIN INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE AS CCU  
+                ON CC.CONSTRAINT_NAME = CCU.CONSTRAINT_NAME
+            WHERE 
+                CC.CONSTRAINT_SCHEMA = ${self.database}
+                AND CCU.TABLE_NAME = ${tableName}
         `);
 
         error? e = from record {} retrievedCheckConstraint in checkConstraintStream


### PR DESCRIPTION
## Purpose

Will move the CheckContraints record from being a field of ColumnDefinition to being a field of TableDefinition.

Mentor: @daneshk 

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility
