### PR TITLE
Fix SQL compiler plugins failure when the diagnostic code is null

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -13,10 +13,10 @@ distribution = "2201.3.0"
 groupId = "io.ballerina.stdlib"
 artifactId = "sql-native"
 version = "1.6.1"
-path = "../native/build/libs/sql-native-1.6.1.jar"
+path = "../native/build/libs/sql-native-1.6.1-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "../test-utils/build/libs/sql-test-utils-1.6.1.jar"
+path = "../test-utils/build/libs/sql-test-utils-1.6.1-SNAPSHOT.jar"
 scope = "testOnly"
 
 [[platform.java11.dependency]]

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "sql"
-version = "1.6.1"
+version = "1.6.2"
 authors = ["Ballerina"]
 keywords = ["database", "client", "network", "SQL", "RDBMS"]
 repository = "https://github.com/ballerina-platform/module-ballerina-sql"
@@ -12,11 +12,11 @@ distribution = "2201.3.0"
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "sql-native"
-version = "1.6.1"
-path = "../native/build/libs/sql-native-1.6.1-SNAPSHOT.jar"
+version = "1.6.2"
+path = "../native/build/libs/sql-native-1.6.2-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "../test-utils/build/libs/sql-test-utils-1.6.1-SNAPSHOT.jar"
+path = "../test-utils/build/libs/sql-test-utils-1.6.2-SNAPSHOT.jar"
 scope = "testOnly"
 
 [[platform.java11.dependency]]

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "sql-compiler-plugin"
 class = "io.ballerina.stdlib.sql.compiler.SQLCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/sql-compiler-plugin-1.6.1.jar"
+path = "../compiler-plugin/build/libs/sql-compiler-plugin-1.6.1-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "sql-compiler-plugin"
 class = "io.ballerina.stdlib.sql.compiler.SQLCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/sql-compiler-plugin-1.6.1-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/sql-compiler-plugin-1.6.2-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -35,7 +35,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "constraint"
-version = "1.0.1"
+version = "1.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
@@ -236,7 +236,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.5.0"
+version = "2.5.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -272,7 +272,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.5"
+version = "1.0.6"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
@@ -291,7 +291,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "regex"
-version = "1.3.1"
+version = "1.3.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -301,7 +301,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "sql"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "io"},

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - [Improve API docs based on Best practices](https://github.com/ballerina-platform/ballerina-standard-library/issues/3857)
+- [Fix SQL compiler plugins failure when the diagnostic code is null](https://github.com/ballerina-platform/ballerina-standard-library/issues/4054)
 
 ## [1.6.1] - 2022-12-22
 

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     testImplementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
     testImplementation group: 'org.ballerinalang', name: 'ballerina-tools-api', version: "${ballerinaLangVersion}"
     testImplementation group: 'org.ballerinalang', name: 'ballerina-parser', version: "${ballerinaLangVersion}"
+    testImplementation group: 'org.ballerinalang', name: 'testerina-core', version: "$ballerinaLangVersion"
 
     implementation group: 'org.testng', name: 'testng', version: "${testngVersion}"
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/sql/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/sql/compiler/CompilerPluginTest.java
@@ -160,8 +160,6 @@ public class CompilerPluginTest {
         Assert.assertEquals(availableErrors, 0);
     }
 
-    // todo Due to the bug https://github.com/ballerina-platform/ballerina-lang/issues/39541
-    // This is only reproducible with `bal build`
     @Test
     public void testDiagnosticsCodeNull() {
         Package currentPackage = loadPackage("sample5");
@@ -172,6 +170,6 @@ public class CompilerPluginTest {
                 .collect(Collectors.toList());
         long availableErrors = errorDiagnosticsList.size();
 
-        Assert.assertEquals(availableErrors, 0);
+        Assert.assertEquals(availableErrors, 1);
     }
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/sql/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/sql/compiler/CompilerPluginTest.java
@@ -159,4 +159,19 @@ public class CompilerPluginTest {
 
         Assert.assertEquals(availableErrors, 0);
     }
+
+    // todo Due to the bug https://github.com/ballerina-platform/ballerina-lang/issues/39541
+    // This is only reproducible with `bal build`
+    @Test
+    public void testDiagnosticsCodeNull() {
+        Package currentPackage = loadPackage("sample5");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        List<Diagnostic> errorDiagnosticsList = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR))
+                .collect(Collectors.toList());
+        long availableErrors = errorDiagnosticsList.size();
+
+        Assert.assertEquals(availableErrors, 0);
+    }
 }

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample5/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample5/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "sql_test"
+name = "sample5"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample5/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample5/main.bal
@@ -1,0 +1,27 @@
+// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/sql;
+
+public function main() returns error? {
+    sql:CharOutParameter charOut = new();
+    string value1 = check charOut.get();
+    string value2 = check charOut.get(string);
+
+    sql:InOutParameter charInOut = new("test");
+    string value3 = check charInOut.get();
+    string value4 = check charInOut.get(string);
+}

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample5/tests/tests.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample5/tests/tests.bal
@@ -1,0 +1,26 @@
+// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+import ballerina/sql;
+
+@test:Mock { functionName: "main"}
+public isolated function mainMock(string input) {
+    sql:CharOutParameter charOut = new();
+    string|error value1 = charOut.get();
+    return;
+}
+

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/sql/compiler/analyzer/MethodAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/sql/compiler/analyzer/MethodAnalyzer.java
@@ -54,10 +54,10 @@ public class MethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
         if (!diagnostics.isEmpty()) {
             diagnostics.stream()
                 .filter(diagnostic -> diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR)
-                .filter(diagnostic ->
+                .filter(diagnostic -> diagnostic.diagnosticInfo().code() != null && (
                         diagnostic.diagnosticInfo().code().equals(CANNOT_INFER_TYPE_FOR_PARAM.diagnosticId()) ||
                                 diagnostic.diagnosticInfo().code().equals(
-                                                    INCOMPATIBLE_TYPE_FOR_INFERRED_TYPEDESC_VALUE.diagnosticId()))
+                                                    INCOMPATIBLE_TYPE_FOR_INFERRED_TYPEDESC_VALUE.diagnosticId())))
                 .filter(diagnostic -> diagnostic.location().lineRange().equals(node.location().lineRange()))
                 .forEach(diagnostic -> addHint(ctx, node));
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.ballerina.stdlib
-version=1.6.1-SNAPSHOT
+version=1.6.2-SNAPSHOT
 
 puppycrawlCheckstyleVersion=8.18
 hikkariLibVersion=3.3.1


### PR DESCRIPTION
## Purpose
$subject

Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/4054

## Checklist
- [x] Linked to an issue
- [ ] ~Updated the specification~
- [x] Updated the changelog
- [x] Added tests
- [x] Checked native-image compatibility
