### PR TITLE
Indicate sql:Column annotation can only be used with Typed records

### DIFF
--- a/ballerina/annotation.bal
+++ b/ballerina/annotation.bal
@@ -21,5 +21,5 @@ public type ColumnConfig record {|
     string name;
 |};
 
-# The Annotation used to specify which database column matches the record field.
+# The Annotation used to specify which database column matches the Typed record field.
 public annotation ColumnConfig Column on record field;

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- [Improve documentation regard `sql:Column` annotation](https://github.com/ballerina-platform/ballerina-standard-library/issues/4134)
 
 ## [1.7.1] - 2023-03-09
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -327,7 +327,7 @@ Here the returned stream can consist of following types of records,
    stream<Student, sql:Error?> resultStream = dbClient->query(query);
    ```
    
-   `sql:Column` annotation can be used to map database columns to record fields of different name. This annotation should be attached to record fields.
+   `sql:Column` annotation can be used to map database columns to Typed record fields of different name. This annotation should be attached to record fields.
    ```ballerina
    type Student record {
        int id;


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/4134

## Examples

## Checklist
- [x] Linked to an issue
- [ ] ~Updated the specification~
- [x] Updated the changelog
- [ ] ~Added tests~
- [ ] ~Checked native-image compatibility~
