### PR TITLE
Revert "Disable all compiler plugin tests"

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,5 @@
 ignore:
   - "test-utils/"
-  - "compiler-plugin/"
 
 coverage:
   precision: 2

--- a/compiler-plugin-tests/src/test/resources/testng.xml
+++ b/compiler-plugin-tests/src/test/resources/testng.xml
@@ -23,7 +23,7 @@
 
     <test name="SQL Compiler Plugin Tests" parallel="false">
         <classes>
-            <!-- <class name="io.ballerina.stdlib.sql.compiler.CompilerPluginTest"/> -->
+            <class name="io.ballerina.stdlib.sql.compiler.CompilerPluginTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
This reverts commit 9645c801bb44695f9ad43f0b73aa8f9eb36e4b1f.

## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/5872

Enabling the testcases as the original issue is fixed

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility
