### PR TITLE
Add CursorInOutParameter type

### DIFF
--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -1352,8 +1352,27 @@ public class InOutParameter {
     } external;
 }
 
+# Represents a Cursor InOut Parameter in `sql:ParameterizedCallQuery`.
+public class CursorInOutParameter {
+    Value 'in;
+
+    // value should be stream<record{}, sql:error>
+    public isolated function init() {
+        self.'in = ();
+    }
+
+    # Gets the cursor value.
+    #
+    # + rowType - The `typedesc` of the record to which the result needs to be returned
+    # + return - The cursor stream of records in the `rowType` type
+    public isolated function get(typedesc<record {}> rowType = <>) returns stream <rowType, Error?> = @java:Method {
+        'class: "io.ballerina.stdlib.sql.nativeimpl.OutParameterProcessor",
+        name: "getOutCursorValue"
+    } external;
+}
+
 # Generic type that can be passed to `sql:ParameterizedCallQuery` to indicate procedure/function parameters.
-public type Parameter Value|InOutParameter|OutParameter|CursorOutParameter;
+public type Parameter Value|InOutParameter|OutParameter|CursorOutParameter|CursorInOutParameter;
 
 # The object constructed through backtick surrounded strings. Dynamic parameters of `sql:Parameter` type can be indicated using `${<variable name>}`
 # such as `` `The sql:ParameterizedQuery is ${variable_name}` ``.

--- a/native/src/main/java/io/ballerina/stdlib/sql/nativeimpl/CallProcessor.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/nativeimpl/CallProcessor.java
@@ -194,6 +194,8 @@ public class CallProcessor {
                 String objectType = TypeUtils.getType(objectValue).getName();
                 if (objectType.equals(Constants.ParameterObject.INOUT_PARAMETER)) {
                     parameterType = Constants.ParameterObject.INOUT_PARAMETER;
+                } else if (objectType.endsWith("InOutParameter")) {
+                    parameterType = Constants.ParameterObject.INOUT_PARAMETER;
                 } else if (objectType.endsWith("OutParameter")) {
                     parameterType = Constants.ParameterObject.OUT_PARAMETER;
                 } else {
@@ -205,7 +207,7 @@ public class CallProcessor {
                     case Constants.ParameterObject.INOUT_PARAMETER:
                         Object innerObject = objectValue.get(Constants.ParameterObject.IN_VALUE_FIELD);
                         sqlType = statementParameterProcessor.setSQLValueParam(connection, statement,
-                                index, innerObject, true);
+                                index, innerObject, true, objectType);
                         outputParamTypes.put(index, sqlType);
                         statement.registerOutParameter(index, sqlType);
                         break;
@@ -216,11 +218,11 @@ public class CallProcessor {
                         break;
                     default:
                         statementParameterProcessor.setSQLValueParam(connection, statement, index,
-                                object, false);
+                                object, false, "");
                 }
             } else {
                 statementParameterProcessor.setSQLValueParam(connection, statement, index, object,
-                        false);
+                        false, "");
             }
         }
     }

--- a/native/src/main/java/io/ballerina/stdlib/sql/parameterprocessor/AbstractStatementParameterProcessor.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/parameterprocessor/AbstractStatementParameterProcessor.java
@@ -203,14 +203,18 @@ public abstract class AbstractStatementParameterProcessor {
         for (int i = 0; i < arrayValue.size(); i++) {
             Object object = arrayValue.get(i);
             int index = i + 1;
-            setSQLValueParam(connection, preparedStatement, index, object, false);
+            setSQLValueParam(connection, preparedStatement, index, object, false, "");
         }
     }
 
     public int setSQLValueParam(Connection connection, PreparedStatement preparedStatement, int index, Object object,
-                                boolean returnType) throws DataError, SQLException {
+                                boolean returnType, String objectType) throws DataError, SQLException {
         try {
             if (object == null) {
+                if (objectType.equals("CursorInOutParameter")) {
+                    preparedStatement.setObject(index, null);
+                    return Types.REF_CURSOR;
+                }
                 preparedStatement.setNull(index, Types.NULL);
                 return Types.NULL;
             } else if (object instanceof BString) {


### PR DESCRIPTION
## Purpose

Fixes:

## Examples
Works for the following code:

Procedure definition:

```sql
        CREATE OR REPLACE FUNCTION GetUserInfo(INOUT curName refcursor)
        LANGUAGE plpgsql
        AS $$
        BEGIN
            OPEN curName FOR
            SELECT user_id, username, email, age
            FROM users;
        END;
        $$;
```
Code: 
```ballerina
import ballerina/sql;
import ballerina/io;
import ballerinax/postgresql; 
import ballerinax/postgresql.driver as _;

public function main() returns error? {
    postgresql:Client dbClient = check new ("localhost", "myuser", "mypassword", "mydatabase", 5432);

    transaction {
        sql:CursorInOutParameter curResults = new;

        sql:ProcedureCallResult result = check dbClient->call(`{CALL GetUserInfo(${curResults})}`);
        stream<record{}, sql:Error?> resultSet = curResults.get();

        record{}[] data = check from record{} assetAllocation in resultSet
           select assetAllocation;

        io:println(data);
        check result.close();
        check commit;

    }
}

```
## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility
