### PR TITLE
Collect XA Resources for transaction recovery feature

### DIFF
--- a/native/src/main/java/io/ballerina/stdlib/sql/datasource/SQLDatasource.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/datasource/SQLDatasource.java
@@ -236,6 +236,18 @@ public class SQLDatasource {
     private static SQLDatasource createAndInitDatasource(SQLDatasource.SQLDatasourceParams sqlDatasourceParams) {
         SQLDatasource newSqlDatasource = new SQLDatasource(sqlDatasourceParams);
         newSqlDatasource.incrementClientCounter();
+        // add new datasource to the recovery manager to be recovered if needed during crash recovery
+        try {
+            XAConnection xaConn = newSqlDatasource.getXAConnection();
+            if (xaConn == null) {
+                return newSqlDatasource;
+            }
+            XAResource xaResource = xaConn.getXAResource();
+            TransactionResourceManager.getInstance().getRecoveryManager().addXAResourceToRecover(xaResource);
+        } catch (SQLException e) {
+            throw ErrorGenerator.getSQLDatabaseError(e,
+                    "error while verifying the connection for " + Constants.CONNECTOR_NAME + ", ");
+        }
         return newSqlDatasource;
     }
 
@@ -246,7 +258,7 @@ public class SQLDatasource {
         return hikariDataSource.getConnection();
     }
 
-    private XAConnection getXAConnection() throws SQLException {
+    public XAConnection getXAConnection() throws SQLException {
         if (isXADataSource()) {
             return xaDataSource.getXAConnection();
         }


### PR DESCRIPTION
## Purpose

For the transaction recovery feature, the transaction manager maintains a list of XA resources. When new data sources are created, an XAResource associated with each data source is generated and registered with the transaction manager. This enables the transaction manager to effectively handle crash recovery for all involved resources.

Related: https://github.com/ballerina-platform/ballerina-lang/issues/42031

Related PRs:
ballerina-lang: https://github.com/ballerina-platform/ballerina-lang/pull/42080
ballerinai-transaction: https://github.com/ballerina-platform/module-ballerinai-transaction/pull/537

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility
