### PR TITLE
Fix strand hanging when strand count exceeds BALLERINA_SQL_MAX_POOL_SIZE

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "sql"
-version = "1.14.1"
+version = "1.14.2"
 authors = ["Ballerina"]
 keywords = ["database", "client", "network", "SQL", "RDBMS"]
 repository = "https://github.com/ballerina-platform/module-ballerina-sql"
@@ -15,11 +15,11 @@ graalvmCompatible = true
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "sql-native"
-version = "1.14.1"
-path = "../native/build/libs/sql-native-1.14.1.jar"
+version = "1.14.2"
+path = "../native/build/libs/sql-native-1.14.2-SNAPSHOT.jar"
 
 [[platform.java17.dependency]]
-path = "../test-utils/build/libs/sql-test-utils-1.14.1.jar"
+path = "../test-utils/build/libs/sql-test-utils-1.14.2-SNAPSHOT.jar"
 scope = "testOnly"
 
 [[platform.java17.dependency]]

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "sql-compiler-plugin"
 class = "io.ballerina.stdlib.sql.compiler.SQLCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/sql-compiler-plugin-1.14.1.jar"
+path = "../compiler-plugin/build/libs/sql-compiler-plugin-1.14.2-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -69,7 +69,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.12.0"
+version = "2.12.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -302,7 +302,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "sql"
-version = "1.14.1"
+version = "1.14.2"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "io"},

--- a/ballerina/tests/query-row-test.bal
+++ b/ballerina/tests/query-row-test.bal
@@ -1652,6 +1652,35 @@ function queryRowEmptyTest2() returns error? {
     test:assertEquals(result, expectedAlbum);
 }
 
+@test:Config {
+    groups: ["query", "query-row"]
+}
+function loadTestQueryRow() returns error? {
+    MockClient dbClient = check getMockClient(queryRowDb);
+    int strandCount = 60;
+    future<Album3|error>[] futures = [];
+    foreach int i in 0 ... strandCount {
+        future<Album3|error> 'future = start queryAlbum3(dbClient);
+        futures.push('future);
+    }
+    Album3 expectedAlbum = {
+        id: "2",
+        name: "Lemonade",
+        artist: (),
+        price: 20.0
+    };
+    foreach int i in 0 ... strandCount {
+        Album3 album = check wait futures.pop();
+        test:assertEquals(album, expectedAlbum);
+    }
+    check dbClient.close();
+}
+
+isolated function queryAlbum3(MockClient dbClient) returns Album3|error {
+    Album3 result = check dbClient->queryRow(`SELECT * FROM Album WHERE id_test = 2`);
+    return result;
+}
+
 isolated function validateDataTableRecordResult(record {}? returnData) {
     decimal decimalVal = 23.45;
     if returnData is () {

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- [Fix strand hanging when strand count exceeds BALLERINA_SQL_MAX_POOL_SIZE](https://github.com/ballerina-platform/ballerina-library/issues/7244)
 
 ## [1.14.1] - 2024-08-29
 

--- a/native/src/main/java/io/ballerina/stdlib/sql/datasource/SQLWorkerThreadPool.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/datasource/SQLWorkerThreadPool.java
@@ -19,7 +19,7 @@
 package io.ballerina.stdlib.sql.datasource;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -41,7 +41,7 @@ public class SQLWorkerThreadPool {
 
     // This is similar to cachedThreadPool util from Executors.newCachedThreadPool(..); but with upper cap on threads
     public static final ExecutorService SQL_EXECUTOR_SERVICE = new ThreadPoolExecutor(0, MAX_POOL_SIZE,
-            60L, TimeUnit.SECONDS, new SynchronousQueue<>(), new SQLThreadFactory());
+            60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), new SQLThreadFactory());
 
     static class SQLThreadFactory implements ThreadFactory {
         @Override


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/7244

The **SynchronousQueue** does not buffer tasks and only acts as a hand-off point. This causes the **ThreadPoolExecutor** to fail with a **RejectedExecutionException**, leading to unexecuted tasks and causing the Ballerina future to remain incomplete. As a result, the Ballerina strand hangs indefinitely.

Changing the **SynchronousQueue** to a **LinkedBlockingQueue** allows for task buffering, which eliminates the **RejectedExecutionException** and improves task execution.

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the specification
- [x] Updated the changelog
- [x] Added tests
- [x] Checked native-image compatibility
