### PR TITLE
[2201.9.x] Fix strand hanging when strand count exceeds BALLERINA_SQL_MAX_POOL_SIZE

### DIFF
--- a/ballerina/tests/query-row-test.bal
+++ b/ballerina/tests/query-row-test.bal
@@ -1652,6 +1652,35 @@ function queryRowEmptyTest2() returns error? {
     test:assertEquals(result, expectedAlbum);
 }
 
+@test:Config {
+    groups: ["query", "query-row"]
+}
+function loadTestQueryRow() returns error? {
+    MockClient dbClient = check getMockClient(queryRowDb);
+    int strandCount = 60;
+    future<Album3|error>[] futures = [];
+    foreach int i in 0 ... strandCount {
+        future<Album3|error> 'future = start queryAlbum3(dbClient);
+        futures.push('future);
+    }
+    Album3 expectedAlbum = {
+        id: "2",
+        name: "Lemonade",
+        artist: (),
+        price: 20.0
+    };
+    foreach int i in 0 ... strandCount {
+        Album3 album = check wait futures.pop();
+        test:assertEquals(album, expectedAlbum);
+    }
+    check dbClient.close();
+}
+
+isolated function queryAlbum3(MockClient dbClient) returns Album3|error {
+    Album3 result = check dbClient->queryRow(`SELECT * FROM Album WHERE id_test = 2`);
+    return result;
+}
+
 isolated function validateDataTableRecordResult(record {}? returnData) {
     decimal decimalVal = 23.45;
     if returnData is () {

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Changed
+- [Fix strand hanging when strand count exceeds BALLERINA_SQL_MAX_POOL_SIZE](https://github.com/ballerina-platform/ballerina-library/issues/7244)
+
+## [1.13.2] - 2024-06-19
 
 ### Changed
 - [Run database queries inside transaction block as non blocking query](https://github.com/ballerina-platform/ballerina-library/issues/6641)

--- a/native/src/main/java/io/ballerina/stdlib/sql/datasource/SQLWorkerThreadPool.java
+++ b/native/src/main/java/io/ballerina/stdlib/sql/datasource/SQLWorkerThreadPool.java
@@ -19,7 +19,7 @@
 package io.ballerina.stdlib.sql.datasource;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -34,7 +34,7 @@ public class SQLWorkerThreadPool {
 
     // This is similar to cachedThreadPool util from Executors.newCachedThreadPool(..); but with upper cap on threads
     public static final ExecutorService SQL_EXECUTOR_SERVICE = new ThreadPoolExecutor(0, 50,
-            60L, TimeUnit.SECONDS, new SynchronousQueue<>(), new SQLThreadFactory());
+            60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), new SQLThreadFactory());
 
     static class SQLThreadFactory implements ThreadFactory {
         @Override


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/7244

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility
