### PR TITLE
Implement getJavaIterator() for BArray and BMap (Merge After Lang 2201.13.0 Query Changes)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.ballerina.stdlib
-version=1.16.1-SNAPSHOT
+version=1.17.0-SNAPSHOT
 ballerinaLangVersion=2201.13.0-20250427-222900-b4ab2445
 
 checkstylePluginVersion=10.12.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=io.ballerina.stdlib
 version=1.16.1-SNAPSHOT
-ballerinaLangVersion=2201.12.0
+ballerinaLangVersion=2201.13.0-20250427-222900-b4ab2445
 
 checkstylePluginVersion=10.12.1
 spotbugsPluginVersion=6.0.18

--- a/native/src/test/java/io/ballerina/stdlib/sql/TestUtils.java
+++ b/native/src/test/java/io/ballerina/stdlib/sql/TestUtils.java
@@ -1145,12 +1145,12 @@ public final class TestUtils {
 
                     @Override
                     public boolean hasNext() {
-                        return iterator.hasNext();
+                        return false;
                     }
 
                     @Override
                     public Object next() {
-                        return iterator.next();
+                        return null;
                     }
                 };
             }
@@ -1330,12 +1330,12 @@ public final class TestUtils {
 
                     @Override
                     public boolean hasNext() {
-                        return iterator.hasNext();
+                        return false;
                     }
 
                     @Override
                     public Object next() {
-                        return iterator.next();
+                        return null;
                     }
                 };
             }

--- a/native/src/test/java/io/ballerina/stdlib/sql/TestUtils.java
+++ b/native/src/test/java/io/ballerina/stdlib/sql/TestUtils.java
@@ -62,6 +62,7 @@ import java.sql.Struct;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -1136,6 +1137,23 @@ public final class TestUtils {
             public Type getType() {
                 return type;
             }
+
+            @Override
+            public Iterator<?> getJavaIterator() {
+                BIterator<?> iterator = getIterator();
+                return new Iterator<>() {
+
+                    @Override
+                    public boolean hasNext() {
+                        return iterator.hasNext();
+                    }
+
+                    @Override
+                    public Object next() {
+                        return iterator.next();
+                    }
+                };
+            }
         };
     }
 
@@ -1303,6 +1321,23 @@ public final class TestUtils {
             @Override
             public Type getType() {
                 return TestUtils.getBooleanStructRecord();
+            }
+
+            @Override
+            public Iterator<?> getJavaIterator() {
+                BIterator<?> iterator = getIterator();
+                return new Iterator<>() {
+
+                    @Override
+                    public boolean hasNext() {
+                        return iterator.hasNext();
+                    }
+
+                    @Override
+                    public Object next() {
+                        return iterator.next();
+                    }
+                };
             }
         };
     }


### PR DESCRIPTION
## Implement getJavaIterator() method for BArray and BMap

An interface `IterableValue` will be introduced for the ballerina collections that supported query, which will enable to get a Java `Iterator` from ballerina collections. `BArray` and `BMap` will extend these interface. As following two return instances from `BArray `and `BMap`, they should implement the method `getJavaIterator()` .

https://github.com/ballerina-platform/module-ballerina-sql/blob/f90668f0196d54c6efef58a5ecce81710591cc38/native/src/test/java/io/ballerina/stdlib/sql/TestUtils.java#L1142 

and 

https://github.com/ballerina-platform/module-ballerina-sql/blob/f90668f0196d54c6efef58a5ecce81710591cc38/native/src/test/java/io/ballerina/stdlib/sql/TestUtils.java#L907

Note: **This PR should be merged after the `query changes` in `Ballerina Lang 2201.13.0` are released**.


Fixes:

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility
