### PR TITLE
[Docs] Clarify `sql:Column` usage when field and column names differ

### DIFF
--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -312,7 +312,7 @@ check from record{} student in resultStream
     };
 ```
 
-When a query result is mapped into a Ballerina record, each database column is matched to a record field **by name**. Ballerina record fields follow the camelCase convention, while database columns are commonly snake_case, so the names frequently do not line up. Use the `sql:Column` annotation to map a record field to its database column **whenever the field name differs from the column name**. The annotation is attached to the record field.
+When a query result is mapped into a Ballerina record, each database column is matched to a record field **by name, ignoring case**. Ballerina record fields follow the camelCase convention, while database columns are commonly snake_case, so the names frequently do not line up. Use the `sql:Column` annotation to map a record field to its database column **when the two names do not match case-insensitively**. The annotation is attached to the record field.
 ```ballerina
 type Student record {
     int id;
@@ -322,7 +322,7 @@ type Student record {
     string lastName;
 };
 ```
-The above maps the database column `first_name` to the Ballerina record field `firstName`. A field whose name already matches its column exactly (for example, an `id` column mapped to an `id` field) does not need the annotation. If the `query()` method does not return the `first_name` column, the field will not be populated.
+The above maps the database column `first_name` to the Ballerina record field `firstName`. A field whose name already matches its column apart from casing (for example, an `ID` column mapped to an `id` field) does not need the annotation. If the `query()` method does not return the `first_name` column, the field will not be populated.
 
 Multiple table columns can be matched to a single Ballerina record within a returned record. For instance if the query returns data from multiple tables such as Students and Teachers.
 All columns of the `Teachers` table can be grouped to another Typed record such as `Teacher` type within the `Student` record.

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -312,17 +312,17 @@ check from record{} student in resultStream
     };
 ```
 
-`sql:Column` annotation can be used to map database columns to Typed record fields of different name. This annotation should be attached to record fields.
+When a query result is mapped into a Ballerina record, each database column is matched to a record field **by name**. Ballerina record fields follow the camelCase convention, while database columns are commonly snake_case, so the names frequently do not line up. Use the `sql:Column` annotation to map a record field to its database column **whenever the field name differs from the column name**. The annotation is attached to the record field.
 ```ballerina
 type Student record {
     int id;
     @sql:Column { name: "first_name" }
     string firstName;
     @sql:Column { name: "last_name" }
-    string lastName
+    string lastName;
 };
 ```
-The above annotation will map the database column `first_name` to the Ballerina record field `firstName`. If the `query()` method does not return `first_name` column, the field will not be populated.
+The above maps the database column `first_name` to the Ballerina record field `firstName`. A field whose name already matches its column exactly (for example, an `id` column mapped to an `id` field) does not need the annotation. If the `query()` method does not return the `first_name` column, the field will not be populated.
 
 Multiple table columns can be matched to a single Ballerina record within a returned record. For instance if the query returns data from multiple tables such as Students and Teachers.
 All columns of the `Teachers` table can be grouped to another Typed record such as `Teacher` type within the `Student` record.


### PR DESCRIPTION
### Purpose

The `sql:Column` section explains *what* the annotation does, but not *when* it is needed. Ballerina records conventionally use camelCase while database columns are commonly snake_case, so the annotation is required far more often than the current wording suggests. Missing it results in silently unpopulated fields, which is a common source of confusion.

### Changes

- Expanded the introduction to state that columns are matched to record fields **by name**, and that the annotation is needed whenever the names differ.
- Noted that a field whose name already matches its column exactly does not need the annotation.
- Fixed a missing semicolon in the `Student` record example (`string lastName` -> `string lastName;`).

These package READMEs are also surfaced as reference context in IDE and AI-assisted tooling, so keeping usage guidance in the README benefits both readers and tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated the package README to clarify that mapping database query result columns to Ballerina record fields is based on column/field name matching **case-insensitively**.
- Refined the guidance for `sql:Column` to recommend using the annotation only when the record field name does **not** match the database column name case-insensitively (e.g., camelCase fields vs snake_case columns).
- Noted that fields that differ only by casing (e.g., `ID` vs `id`) do not require `sql:Column`, and corrected the `Student` record example syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->